### PR TITLE
docs: add CA definition as certificate authorities to help other user…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The certificate is at "./example.com+5.pem" and the key at "./example.com+5-key.
 
 <p align="center"><img width="444" alt="Chrome screenshot" src="https://user-images.githubusercontent.com/1225294/41887838-7acd55ca-78d0-11e8-8a81-139a54faaf87.png"></p>
 
-Using certificates from real CAs for development can be dangerous or impossible (for hosts like `localhost` or `127.0.0.1`), but self-signed certificates cause trust errors. Managing your own CA is the best solution, but usually involves arcane commands, specialized knowledge and manual steps.
+Using certificates from real certificate authorities (CAs) for development can be dangerous or impossible (for hosts like `localhost` or `127.0.0.1`), but self-signed certificates cause trust errors. Managing your own CA is the best solution, but usually involves arcane commands, specialized knowledge and manual steps.
 
 mkcert automatically creates and installs a local CA in the system root store, and generates locally-trusted certificates.
 
@@ -50,13 +50,13 @@ Windows will be supported next.
 
 ### Changing the location of the CA files
 
-The CA certificate and its key are stored in an application data folder in the user home. You usually don't have to worry about it, as installation is automated, but if you need it it's printed in the first line of the mkcert output.
+The CA certificate and its key are stored in an application data folder in the user home. You usually don't have to worry about it, as installation is automated, but it's printed in the first line of the mkcert output.
 
 If you want to manage separate CAs, you can use the environment variable `CAROOT` to set the folder where mkcert will place and look for the local CA files.
 
 ### Installing the CA on other computers
 
-Installing in the trust store does not require the CA key, so you can export just the CA certificate and use mkcert to install it in other machines. For example, you can decide to commit just `rootCA.pem` and not its key to version control.
+Installing in the trust store does not require the CA key, so you can export the CA certificate and use mkcert to install it in other machines. For example, you can decide to commit just `rootCA.pem` and not its key to version control.
 
 * Look for the `rootCA.pem` file in `CAROOT` or in the default folder (see above)
 * copy it to a different machine

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you want to manage separate CAs, you can use the environment variable `$CAROO
 
 ### Installing the CA on other systems
 
-Installing in the trust store does not require the CA key, so you can export only the CA certificate and use mkcert to install it in other machines.
+Installing in the trust store does not require the CA key, so you can export the CA certificate and use mkcert to install it in other machines.
 
 * Look for the `rootCA.pem` file in `mkcert -CAROOT`
 * copy it to a different machine


### PR DESCRIPTION
…s understand the documentation and removed some redundant text for readability