### PR TITLE
Use `go get` to build from source in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ brew install nss # if you use Firefox
 On Linux (`-install` support coming soon!), use [the pre-built binaries (again, coming soon)](https://github.com/FiloSottile/mkcert/releases), or build from source (requires Go 1.10+).
 
 ```
-$ git clone https://github.com/FiloSottile/mkcert
-$ cd mkcert && make
+go get -u github.com/FiloSottile/mkcert
 ```
 
 Windows will be supported next.


### PR DESCRIPTION
This automatically downloads the mkcert source code, builds it and installs the binary into `$GOPATH/bin`. This command can also be used to update an existing mkcert installation.