### PR TITLE
truststore: check if profile is a directory before joining cert*.db

### DIFF
--- a/truststore_nss.go
+++ b/truststore_nss.go
@@ -97,6 +97,9 @@ func (m *mkcert) forEachNSSProfile(f func(profile string)) (found int) {
 		return
 	}
 	for _, profile := range profiles {
+		if stat, err := os.Stat(profile); err == nil && stat != nil && !stat.IsDir() {
+			continue
+		}
 		if _, err := os.Stat(filepath.Join(profile, "cert8.db")); !os.IsNotExist(err) {
 			f("dbm:" + profile)
 			found++

--- a/truststore_nss.go
+++ b/truststore_nss.go
@@ -97,7 +97,7 @@ func (m *mkcert) forEachNSSProfile(f func(profile string)) (found int) {
 		return
 	}
 	for _, profile := range profiles {
-		if stat, err := os.Stat(profile); err == nil && stat != nil && !stat.IsDir() {
+		if stat, err := os.Stat(profile); err != nil || !stat.IsDir() {
 			continue
 		}
 		if _, err := os.Stat(filepath.Join(profile, "cert8.db")); !os.IsNotExist(err) {


### PR DESCRIPTION
This should fix FiloSottile/mkcert#12, because the `FirefoxProfile` glob also matches files like `profile.ini`.