### PR TITLE
support install into java cacerts file

### DIFF
--- a/main.go
+++ b/main.go
@@ -185,9 +185,9 @@ func (m *mkcert) install() {
 	if hasJava && !m.checkJava() {
 		if hasKeytool {
 			m.installJava()
-			log.Println("The local CA is now installed in Java's trust store ☕️")
+			log.Println("The local CA is now installed in Java's trust store! ☕️")
 		} else {
-			log.Println(`Warning: "keytool" is not available, so the CA can't be automatically installed in Java! ⚠️`)
+			log.Println(`Warning: "keytool" is not available, so the CA can't be automatically installed in Java's trust store! ⚠️`)
 		}
 		printed = true
 	}
@@ -212,7 +212,7 @@ func (m *mkcert) uninstall() {
 			m.uninstallJava()
 		} else {
 			log.Print("")
-			log.Println(`Warning: "keytool" is not available, so the CA can't be automatically uninstalled from Java (if it was ever installed)! ⚠`)
+			log.Println(`Warning: "keytool" is not available, so the CA can't be automatically uninstalled from Java's trust store (if it was ever installed)! ⚠️`)
 			log.Print("")
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -83,6 +83,10 @@ func (m *mkcert) Run(args []string) {
 			warning = true
 			log.Printf("Warning: the local CA is not installed in the %s trust store! ⚠️", NSSBrowsers)
 		}
+		if hasJava && !m.checkJava() {
+			warning = true
+			log.Println("Warning: the local CA is not installed in the Java trust store! ⚠️")
+		}
 		if warning {
 			log.Println("Run \"mkcert -install\" to avoid verification errors ‼️")
 		}
@@ -178,6 +182,15 @@ func (m *mkcert) install() {
 		}
 		printed = true
 	}
+	if hasJava && !m.checkJava() {
+		if hasKeytool {
+			m.installJava()
+			log.Println("The local CA is now installed in Java's trust store ☕️")
+		} else {
+			log.Println(`Warning: "keytool" is not available, so the CA can't be automatically installed in Java! ⚠️`)
+		}
+		printed = true
+	}
 	if printed {
 		log.Print("")
 	}
@@ -191,6 +204,15 @@ func (m *mkcert) uninstall() {
 			log.Print("")
 			log.Printf(`Warning: "certutil" is not available, so the CA can't be automatically uninstalled from %s (if it was ever installed)! ⚠️`, NSSBrowsers)
 			log.Printf(`You can install "certutil" with "%s" and re-run "mkcert -uninstall" 👈`, CertutilInstallHelp)
+			log.Print("")
+		}
+	}
+	if hasJava {
+		if hasKeytool {
+			m.uninstallJava()
+		} else {
+			log.Print("")
+			log.Println(`Warning: "keytool" is not available, so the CA can't be automatically uninstalled from Java (if it was ever installed)! ⚠`)
 			log.Print("")
 		}
 	}

--- a/truststore_java.go
+++ b/truststore_java.go
@@ -1,3 +1,7 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/truststore_java.go
+++ b/truststore_java.go
@@ -47,10 +47,7 @@ func (m *mkcert) checkJava() bool {
 	// exists returns true if the given x509.Certificate's fingerprint
 	// is in the keytool -list output
 	exists := func(c *x509.Certificate, h hash.Hash, keytoolOutput []byte) bool {
-		_, err := h.Write(c.Raw)
-		if err != nil {
-			return false
-		}
+		h.Write(c.Raw)
 		fp := strings.ToUpper(hex.EncodeToString(h.Sum(nil)))
 		return bytes.Contains(keytoolOutput, []byte(fp))
 	}

--- a/truststore_java.go
+++ b/truststore_java.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"hash"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	hasJava    bool
+	hasKeytool bool
+
+	javaHome    string
+	cacertsPath string
+	keytoolPath string
+	storePass   string = "changeit"
+)
+
+func init() {
+	if v := os.Getenv("JAVA_HOME"); v != "" {
+		hasJava = true
+		javaHome = v
+
+		_, err := os.Stat(path.Join(v, "bin/keytool"))
+		if err == nil {
+			hasKeytool = true
+			keytoolPath = path.Join(v, "bin/keytool")
+		}
+
+		cacertsPath = path.Join(v, "jre/lib/security/cacerts")
+	}
+}
+
+func (m *mkcert) checkJava() bool {
+	// exists returns true if the given x509.Certificate's fingerprint
+	// is in the keytool -list output
+	exists := func(c *x509.Certificate, h hash.Hash, keytoolOutput []byte) bool {
+		_, err := h.Write(c.Raw)
+		if err != nil {
+			return false
+		}
+		fp := strings.ToUpper(hex.EncodeToString(h.Sum(nil)))
+		return bytes.Contains(keytoolOutput, []byte(fp))
+	}
+
+	keytoolOutput, err := exec.Command(keytoolPath, "-list", "-keystore", cacertsPath, "-storepass", storePass).CombinedOutput()
+	fatalIfCmdErr(err, "keytool -list", keytoolOutput)
+	// keytool outputs SHA1 and SHA256 (Java 9+) certificates in uppercase hex
+	// with each octet pair delimitated by ":". Drop them from the keytool output
+	keytoolOutput = bytes.Replace(keytoolOutput, []byte(":"), nil, -1)
+
+	// pre-Java 9 uses SHA1 fingerprints
+	s1, s256 := sha1.New(), sha256.New()
+	return exists(m.caCert, s1, keytoolOutput) || exists(m.caCert, s256, keytoolOutput)
+}
+
+func (m *mkcert) installJava() {
+	args := []string{
+		"-importcert", "-noprompt",
+		"-keystore", cacertsPath,
+		"-storepass", storePass,
+		"-file", filepath.Join(m.CAROOT, rootName),
+		"-alias", m.caUniqueName(),
+	}
+
+	out, err := m.execKeytool(exec.Command(keytoolPath, args...))
+	fatalIfCmdErr(err, "keytool -importcert", out)
+}
+
+func (m *mkcert) uninstallJava() {
+	args := []string{
+		"-delete",
+		"-alias", m.caUniqueName(),
+		"-keystore", cacertsPath,
+		"-storepass", storePass,
+	}
+	out, err := m.execKeytool(exec.Command(keytoolPath, args...))
+	if bytes.Contains(out, []byte("does not exist")) {
+		return // cert didn't exist
+	}
+	fatalIfCmdErr(err, "keytool -delete", out)
+}
+
+// execKeytool will execute a "keytool" command and if needed re-execute
+// the command wrapped in 'sudo' to work around file permissions.
+func (m *mkcert) execKeytool(cmd *exec.Cmd) ([]byte, error) {
+	out, err := cmd.CombinedOutput()
+	if err != nil && bytes.Contains(out, []byte("java.io.FileNotFoundException")) {
+		origArgs := cmd.Args[1:]
+		cmd = exec.Command("sudo", keytoolPath)
+		cmd.Args = append(cmd.Args, origArgs...)
+		cmd.Env = []string{
+			"JAVA_HOME=" + javaHome,
+		}
+		out, err = cmd.CombinedOutput()
+	}
+	return out, err
+}


### PR DESCRIPTION
This works for me locally on a Mac with Java 8 and 9. I'm going to test out a bit on linux and newer Java versions. 

```
$ ./bin/mkcert -install
Using the local CA at "/Users/adam/Library/Application Support/mkcert" ✨
The local CA is now installed in the system trust store! ⚡️
The local CA is now installed in the Firefox trust store (requires browser restart)! 🦊
The local CA is now installed in Java's trust store ☕️

$ keytool -list -keystore $JAVA_HOME/jre/lib/security/cacerts -storepass changeit | grep -i mkcert
mkcert development ca 215883752978067404179277978616948247614, Jul 6, 2018, trustedCertEntry, 
```