### PR TITLE
Use $XDG_DATA_HOME on macOS if it is set.

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,6 +140,8 @@ func getCAROOT() string {
 	switch runtime.GOOS {
 	case "windows":
 		dir = os.Getenv("LocalAppData")
+	case env = os.Getenv("XDG_DATA_HOME"); env != "":
+		dir = env
 	case "darwin":
 		dir = os.Getenv("HOME")
 		if dir == "" {
@@ -147,14 +149,11 @@ func getCAROOT() string {
 		}
 		dir = filepath.Join(dir, "Library", "Application Support")
 	default: // Unix
-		dir = os.Getenv("XDG_DATA_HOME")
+		dir = os.Getenv("HOME")
 		if dir == "" {
-			dir = os.Getenv("HOME")
-			if dir == "" {
-				return ""
-			}
-			dir = filepath.Join(dir, ".local", "share")
+			return ""
 		}
+		dir = filepath.Join(dir, ".local", "share")
 	}
 	return filepath.Join(dir, "mkcert")
 }


### PR DESCRIPTION
I was a little surprised to see `mkcert` use `~/Library/Application Support` instead of `$XDG_DATA_HOME` until I looked at the code and see it was intentional choice.

I personally think it would be good to follow the  XDG spec full and default to `~/.local/share` on macOS – rather than introducing custom behaviour – but it's ultimately up to you.

This PR offers a compromise, using `$XDG_DATA_HOME` if set, if you'd be okay with that. :-)
(I explicitly set XDG config vars in my shell, in order to try to get as many programs to use the same data storage structure as possible.)