### PR TITLE
detect firefox developer edition

### DIFF
--- a/truststore_darwin.go
+++ b/truststore_darwin.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	FirefoxPath         = "/Applications/Firefox.app"
+	FirefoxPaths        = []string{"/Applications/Firefox.app", "/Applications/FirefoxDeveloperEdition.app"}
 	FirefoxProfile      = os.Getenv("HOME") + "/Library/Application Support/Firefox/Profiles/*"
 	CertutilInstallHelp = "brew install nss"
 	NSSBrowsers         = "Firefox"

--- a/truststore_linux.go
+++ b/truststore_linux.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	FirefoxPath         = "/usr/bin/firefox"
+	FirefoxPaths        = []string{"/usr/bin/firefox"}
 	FirefoxProfile      = os.Getenv("HOME") + "/.mozilla/firefox/*"
 	CertutilInstallHelp = `apt install libnss3-tools" or "yum install nss-tools`
 	NSSBrowsers         = "Firefox and/or Chrome/Chromium"

--- a/truststore_nss.go
+++ b/truststore_nss.go
@@ -16,9 +16,19 @@ var (
 	nssDB        = filepath.Join(os.Getenv("HOME"), ".pki/nssdb")
 )
 
+func hasFirefox() bool {
+	for _, firefoxPath := range FirefoxPaths {
+		_, err := os.Stat(firefoxPath)
+		hasNSS := !os.IsNotExist(err)
+		if hasNSS {
+			return true
+		}
+	}
+	return false
+}
+
 func init() {
-	_, err := os.Stat(FirefoxPath)
-	hasNSS = !os.IsNotExist(err)
+	hasNSS = hasFirefox()
 
 	switch runtime.GOOS {
 	case "darwin":


### PR DESCRIPTION
I am currently using [Firefox Developer Edition](https://www.mozilla.org/es-AR/firefox/developer/) (aka Quantum) in mac, and the path for the application is `/Applications/FirefoxDeveloperEdition.app` instead of just `/Applications/Firefox.app`.

So, here is my small contribution. I am new to GO so let me know if there is something I could do better. 

Thank you for this awesome project