### PR TITLE
Support installing to system trust store for Arch-based distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ On Linux, install `certutil`
 sudo apt install libnss3-tools
     -or-
 sudo yum install nss-tools
+    -or-
+sudo pacman -S nss
 ```
 
 and build from source (requires Go 1.10+), or use [the pre-built binaries](https://github.com/FiloSottile/mkcert/releases).
@@ -69,7 +71,7 @@ mkcert supports the following root stores:
 * macOS system store
 * Windows system store
 * Linux variants that provide either
-    * `update-ca-trust` (Fedora, RHEL, CentOS) or
+    * `update-ca-trust` (Fedora, RHEL, CentOS, Arch) or
     * `update-ca-certificates` (Ubuntu, Debian)
 * Firefox (macOS and Linux only)
 * Chrome and Chromium

--- a/truststore_linux.go
+++ b/truststore_linux.go
@@ -24,16 +24,15 @@ var (
 )
 
 func init() {
-	_, err := os.Stat("/etc/pki/ca-trust/source/anchors/")
-	if err == nil {
+	if pathExists("/etc/pki/ca-trust/source/anchors/") {
 		SystemTrustFilename = "/etc/pki/ca-trust/source/anchors/mkcert-rootCA.pem"
 		SystemTrustCommand = []string{"update-ca-trust", "extract"}
-	} else {
-		_, err = os.Stat("/usr/local/share/ca-certificates/")
-		if err == nil {
-			SystemTrustFilename = "/usr/local/share/ca-certificates/mkcert-rootCA.crt"
-			SystemTrustCommand = []string{"update-ca-certificates"}
-		}
+	} else if pathExists("/usr/local/share/ca-certificates/") {
+		SystemTrustFilename = "/usr/local/share/ca-certificates/mkcert-rootCA.crt"
+		SystemTrustCommand = []string{"update-ca-certificates"}
+	} else if pathExists("/etc/ca-certificates/trust-source/anchors/") {
+		SystemTrustFilename = "/etc/ca-certificates/trust-source/anchors/mkcert-rootCA.crt"
+		SystemTrustCommand = []string{"trust", "extract-compat"}
 	}
 	if SystemTrustCommand != nil {
 		_, err := exec.LookPath(SystemTrustCommand[0])
@@ -41,6 +40,11 @@ func init() {
 			SystemTrustCommand = nil
 		}
 	}
+}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func (m *mkcert) installPlatform() bool {


### PR DESCRIPTION
Arch ca-certificates reference: https://www.archlinux.org/news/ca-certificates-update/

Working for me on Manjaro Linux 17.1.11.