### PR TITLE
Added -password flag to allow specifying  of PKCS#12 password

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -95,7 +95,7 @@ func (m *mkcert) makeCert(hosts []string) {
 		fatalIfErr(err, "failed to save certificate key")
 	} else {
 		domainCert, _ := x509.ParseCertificate(cert)
-		pfxData, err := pkcs12.Encode(rand.Reader, priv, domainCert, []*x509.Certificate{m.caCert}, "changeit")
+		pfxData, err := pkcs12.Encode(rand.Reader, priv, domainCert, []*x509.Certificate{m.caCert}, m.password)
 		fatalIfErr(err, "failed to generate PKCS#12")
 		err = ioutil.WriteFile(filename+".p12", pfxData, 0644)
 		fatalIfErr(err, "failed to save PKCS#12")

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ const usage = `Usage of mkcert:
 	Generate "_wildcard.example.com.pem" and "_wildcard.example.com-key.pem".
 
 	$ mkcert -pkcs12 example.com
-	Generate "example.com.p12" instead of a PEM file.
+	Generate "example.com.p12" instead of a PEM file. The default password is "changeit".
 
 	$ mkcert -uninstall
 	Uninstall the local CA (but do not delete it).
@@ -49,6 +49,7 @@ func main() {
 	var installFlag = flag.Bool("install", false, "install the local root CA in the system trust store")
 	var uninstallFlag = flag.Bool("uninstall", false, "uninstall the local root CA from the system trust store")
 	var pkcs12Flag = flag.Bool("pkcs12", false, "generate PKCS#12 instead of PEM")
+	var passwordFlag = flag.String("password", "changeit", "override the default PKCS#12 password of 'changeit'")
 	var carootFlag = flag.Bool("CAROOT", false, "print the CAROOT path")
 	flag.Usage = func() { fmt.Fprintf(flag.CommandLine.Output(), usage) }
 	flag.Parse()
@@ -63,7 +64,7 @@ func main() {
 		log.Fatalln("ERROR: you can't set -install and -uninstall at the same time")
 	}
 	(&mkcert{
-		installMode: *installFlag, uninstallMode: *uninstallFlag, pkcs12: *pkcs12Flag,
+		installMode: *installFlag, uninstallMode: *uninstallFlag, pkcs12: *pkcs12Flag, password: *passwordFlag,
 	}).Run(flag.Args())
 }
 
@@ -73,6 +74,7 @@ const keyName = "rootCA-key.pem"
 type mkcert struct {
 	installMode, uninstallMode bool
 	pkcs12                     bool
+	password                   string
 
 	CAROOT string
 	caCert *x509.Certificate


### PR DESCRIPTION
Hi,

I didn't like that the PKCS#12 support didn't allow you to specify the password, so I added a flag to pass in your own. I also updated the usage text as it was not immediately obvious _what_ the default password even was.

I've never touched Go before, so apologies if I've made a mistake. Feel free to feedback on anything that should have been done differently.

I've signed the CLA as well.