### PR TITLE
Mentioned Linuxbrew as the preferred way to install mkcert on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ mkcert automatically creates and installs a local CA in the system root store, a
 
 ## Installation
 
-On macOS, use Homebrew.
+On macOS, use [Homebrew](https://brew.sh/).
 
 ```
 brew install mkcert
@@ -44,8 +44,13 @@ sudo apt install libnss3-tools
     -or-
 sudo yum install nss-tools
 ```
+and install using [Linuxbrew](http://linuxbrew.sh/).
 
-and build from source (requires Go 1.10+), or use [the pre-built binaries](https://github.com/FiloSottile/mkcert/releases).
+```
+brew install mkcert
+````
+
+You can also build from source (requires Go 1.10+), or use [the pre-built binaries](https://github.com/FiloSottile/mkcert/releases).
 
 ```
 go get -u github.com/FiloSottile/mkcert


### PR DESCRIPTION
Linuxbrew already packaged mkcert for Linux.

There's no need to build from source or periodically check here for updates.
Hence, it should be the preferred way to install mkcert.
I've re-phrased the README to reflect that.