### PR TITLE
Update README with info on how to install via MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ brew install mkcert
 brew install nss # if you use Firefox
 ```
 
+Additionally on macOS, you can also use MacPorts.
+
+```
+sudo port sync
+sudo port install mkcert
+```
+
 On Linux, install `certutil`
 
 ```


### PR DESCRIPTION
You can now install mkcert via MacPorts.  Just adding information on how to do so in the README.