### PR TITLE
Add "choco install" for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ On Arch Linux you can use your [AUR helper](https://wiki.archlinux.org/index.php
 yaourt -S mkcert
 ```
 
-On Windows build from source (requires Go 1.10+), or use [the pre-built binaries](https://github.com/FiloSottile/mkcert/releases).
+On Windows, use Chocolatey.
+
+```
+choco install mkcert
+```
+
+Or build from source (requires Go 1.10+), or use [the pre-built binaries](https://github.com/FiloSottile/mkcert/releases).
 
 > **Warning**: the `rootCA-key.pem` file that mkcert automatically generates gives complete power to intercept secure requests from your machine. Do not share it.
 


### PR DESCRIPTION
I love this tool and that it's so easy on macOS to use `brew install mkcert`.
I've created a Chocolatey package which is pending in review right now, but should be published very soon. ( https://chocolatey.org/packages/mkcert )
So on Windows someone can use `choco install mkcert` to install the current version or a specific version.

The choco package sources are at https://github.com/StefanScherer/choco-mkcert with a small CI pipeline to test the package in AppVeyor which was green for the 1.1.0 release https://ci.appveyor.com/project/StefanScherer/choco-mkcert/branch/master

If you want to have the choco package maintained in your repo, please let me know.