### PR TITLE
Add scoop install for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ On Windows, use Chocolatey
 choco install mkcert
 ```
 
+or use Scoop
+
+```
+scoop install mkcert
+```
+
 or build from source (requires Go 1.10+), or use [the pre-built binaries](https://github.com/FiloSottile/mkcert/releases).
 
 ## Supported root stores


### PR DESCRIPTION
Same as #63 but for [Scoop installer for Windows](https://github.com/lukesampson/scoop).

See https://github.com/lukesampson/scoop/wiki/Chocolatey-Comparison

I'm waiting for PR approval in the _extras bucket_ https://github.com/lukesampson/scoop-extras/pull/1153
the script is auto-updating and will be maintained externally.

Meanwhile the app manifest is publicly available on my fork and anyone can install it:

```ps
$ scoop install https://raw.githubusercontent.com/filippobuletto/scoop-extras/master/mkcert.json
```