### PR TITLE
docs: clarify mkcert doens't configure servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The certificate is at "./example.com+5.pem" and the key at "./example.com+5-key.
 
 Using certificates from real certificate authorities (CAs) for development can be dangerous or impossible (for hosts like `localhost` or `127.0.0.1`), but self-signed certificates cause trust errors. Managing your own CA is the best solution, but usually involves arcane commands, specialized knowledge and manual steps.
 
-mkcert automatically creates and installs a local CA in the system root store, and generates locally-trusted certificates. mkcert does not automatically configure servers to use the certificates.
+mkcert automatically creates and installs a local CA in the system root store, and generates locally-trusted certificates. mkcert does not automatically configure servers to use the certificates, though, that's up to you.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The certificate is at "./example.com+5.pem" and the key at "./example.com+5-key.
 
 Using certificates from real certificate authorities (CAs) for development can be dangerous or impossible (for hosts like `localhost` or `127.0.0.1`), but self-signed certificates cause trust errors. Managing your own CA is the best solution, but usually involves arcane commands, specialized knowledge and manual steps.
 
-mkcert automatically creates and installs a local CA in the system root store, and generates locally-trusted certificates.
+mkcert automatically creates and installs a local CA in the system root store, and generates locally-trusted certificates. mkcert does not automatically configure servers to use the certificates.
 
 ## Installation
 


### PR DESCRIPTION
This has come up a few times so let's clarify in the docs. 