### PR TITLE
Add support for client certificates

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -51,6 +51,13 @@ func (m *mkcert) makeCert(hosts []string) {
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	fatalIfErr(err, "failed to generate serial number")
 
+	var extKeyUsage []x509.ExtKeyUsage
+	if m.client {
+		extKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	} else {
+		extKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	}
+
 	tpl := &x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
@@ -62,7 +69,7 @@ func (m *mkcert) makeCert(hosts []string) {
 		NotBefore: time.Now(),
 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		ExtKeyUsage:           extKeyUsage,
 		BasicConstraintsValid: true,
 	}
 	for _, h := range hosts {

--- a/main.go
+++ b/main.go
@@ -37,6 +37,9 @@ const usage = `Usage of mkcert:
 	$ mkcert -pkcs12 example.com
 	Generate "example.com.p12" instead of a PEM file.
 
+	$ mkcert -client example.com
+	Generate "example.com.pem" as a client certificate.
+
 	$ mkcert -uninstall
 	Uninstall the local CA (but do not delete it).
 
@@ -49,6 +52,7 @@ func main() {
 	var installFlag = flag.Bool("install", false, "install the local root CA in the system trust store")
 	var uninstallFlag = flag.Bool("uninstall", false, "uninstall the local root CA from the system trust store")
 	var pkcs12Flag = flag.Bool("pkcs12", false, "generate PKCS#12 instead of PEM")
+	var clientFlag = flag.Bool("client", false, "generate a client certificate")
 	var carootFlag = flag.Bool("CAROOT", false, "print the CAROOT path")
 	flag.Usage = func() { fmt.Fprintf(flag.CommandLine.Output(), usage) }
 	flag.Parse()
@@ -63,7 +67,7 @@ func main() {
 		log.Fatalln("ERROR: you can't set -install and -uninstall at the same time")
 	}
 	(&mkcert{
-		installMode: *installFlag, uninstallMode: *uninstallFlag, pkcs12: *pkcs12Flag,
+		installMode: *installFlag, uninstallMode: *uninstallFlag, pkcs12: *pkcs12Flag, client: *clientFlag,
 	}).Run(flag.Args())
 }
 
@@ -73,6 +77,7 @@ const keyName = "rootCA-key.pem"
 type mkcert struct {
 	installMode, uninstallMode bool
 	pkcs12                     bool
+	client                     bool
 
 	CAROOT string
 	caCert *x509.Certificate


### PR DESCRIPTION
This change adds a new flag for client certificates. When this flag is passed, the extended key usage for the generated certificate is for client authentication instead of server authentication.

I am not 100% sure this is a good idea, but I found myself needing to generate both server and client certificates for a project and thought that `mkcert` could fit both of those cases.

The change was remarkably easy to make so I figured I'd submit a PR.