### PR TITLE
java: don't run keytool during check if we there isn't even one found

### DIFF
--- a/truststore_java.go
+++ b/truststore_java.go
@@ -58,6 +58,10 @@ func init() {
 }
 
 func (m *mkcert) checkJava() bool {
+	if !hasKeytool {
+		return false
+	}
+
 	// exists returns true if the given x509.Certificate's fingerprint
 	// is in the keytool -list output
 	exists := func(c *x509.Certificate, h hash.Hash, keytoolOutput []byte) bool {


### PR DESCRIPTION
If JAVA_HOME isn't set then keytoolPath has an invalid path. This means checkJava() fails and doesn't tell the problem clearly to the user.

Issue: https://github.com/FiloSottile/mkcert/issues/88