### PR TITLE
README: AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,12 @@ $(go env GOPATH)/bin/mkcert
 
 or use [the pre-built binaries](https://github.com/FiloSottile/mkcert/releases).
 
-On Arch Linux you can use your [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) to install mkcert from the [PKGBUILD](https://aur.archlinux.org/packages/mkcert/).
+For Arch Linux users, mkcert is available from AUR as [`mkcert`](https://aur.archlinux.org/packages/mkcert/) or [`mkcert-git`](https://aur.archlinux.org/packages/mkcert-git/).
 
-```
-yaourt -S mkcert
+```bash
+git clone https://aur.archlinux.org/mkcert.git
+cd mkcert
+makepkg -si
 ```
 
 ### Windows


### PR DESCRIPTION
## Rationale

Arch Linux does not support AUR helpers ([ref](https://wiki.archlinux.org/index.php/AUR_helpers)), so the README should reflect the recommended [install process](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages).

I realize this is pedantic, but users should be guided towards the Arch way of installing AUR packages, and not to a single user's preferred method of managing AUR packages.

## Code change

No code has been changed, only the `README.md` file has been altered.