### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: mkcert
+version: '1.0'
+summary: A simple zero-config tool to make locally trusted development certificate
+description: |
+  A simple zero-config tool to make locally trusted development certificates with any names you'd like.
+grade: stable
+confinement: strict
+base: core18
+parts:
+  mkcert:
+    plugin: go
+    source: https://github.com/FiloSottile/mkcert.git
+    go-importpath: github.com/FiloSottile/mkcert
+    build-packages:
+      - build-essential
+      - libnss3-tools
+apps:
+  mkcert:
+    command: bin/mkcert
+    plugs:
+      - home


### PR DESCRIPTION
Hi Filippo,

Mkcert looks like an interesting tool - I wish I had this back in 2008 when I was doing a lot of stuff around web servers. Oh well.

Anyway, I want to ask you to add support for snaps.

Now, snaps are cross-distro Linux software packages, supported on LTS and non-LTS Ubuntu, as well as many others distributions. Having mkcert as a snap would make it available to millions of users through the Snap Store (snapcraft.io/store), and also allow you to provide automatic updates with any changes to all your users. I guess this would make a lot of sense if there are vulnerabilities in the nss library, and people need updates fast, and you want to make sure everyone is fully aligned.

Snaps make for a really good use case here, as they are self-contained and isolated. In fact, I built mkcert as a strictly confined application, and if you decide to do snap building, you can play and tweak with whatthe snap can do some more.

TL;DR - technical details - for how to build snaps locally. I used Ubuntu 18.04 LTS as the build system.

snap install snapcraft --classic --beta
git clone https://github.com/igorljubuncic/mkcert.git
cd mkcert
git checkout add-snapcraft
snapcraft

The last command creates a <mkcert-version>.snap file, something like mkcert_1.0_amd64.snap.

This snap can be installed and tested locally with:

snap install mkcert_1.0_amd64.snap --dangerous

The --dangerous flag is necessary because the snap hasn’t yet gone through the snap store review process and is not digitally signed.

The mkcert command can be executed, e.g.: snap run mkcert <options>.

Then, you will need to get the snap actually published in the store:

- Register a developer account in the snap store https://snapcraft.io/account.
- Register the mkcert name in the store. 

snapcraft login
snapcraft register

- Upload a built snap to the store. The store supports multiple risk levels as “channels”. We have edge, beta, candidate and stable, which denote the level of stability. Typically, you start with edge and promote to other channels as you complete testing and validation.

snapcraft push mkcert_1.0_amd64.snap --release edge

- Test installing on a clean machine to see everything works as you expect.

snap install mkcert --edge

After you have completed your testing and you're happy, you can push a stable release to the stable channel. The next step after that is to update the store page, and promote the application online. We will gladly help there, and we'd be happy to feature your application in our store. Feel free to reach out if you have any questions or concerns.
