### PR TITLE
Add 'Firefox Nightly.app' for macOS.

### DIFF
--- a/truststore_nss.go
+++ b/truststore_nss.go
@@ -20,6 +20,7 @@ func init() {
 	for _, path := range []string{
 		"/usr/bin/firefox", nssDB, "/Applications/Firefox.app",
 		"/Applications/Firefox Developer Edition.app",
+		"/Applications/Firefox Nightly.app",
 		"C:\\Program Files\\Mozilla Firefox",
 	} {
 		_, err := os.Stat(path)


### PR DESCRIPTION
Added FirefoxNightly.app for macOS, as similar to 'Firefox Developer Edition', it gets installed with a different name (as per brew https://github.com/Homebrew/homebrew-cask-versions/blob/8a61151ae75b0d87723e024256b036c511cd6096/Casks/firefox-nightly.rb#L112)