### PR TITLE
Rename file extension for more cross-platforms friendly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Created a new certificate valid for the following names 📜
  - "127.0.0.1"
  - "::1"
 
-The certificate is at "./example.com+5.pem" and the key at "./example.com+5-key.pem" ✅
+The certificate is at "./example.com+5.crt" and the key at "./example.com+5.key" ✅
 ```
 
 <p align="center"><img width="498" alt="Chrome and Firefox screenshot" src="https://user-images.githubusercontent.com/1225294/51066373-96d4aa80-15be-11e9-91e2-f4e44a3a4458.png"></p>
@@ -30,7 +30,7 @@ mkcert automatically creates and installs a local CA in the system root store, a
 
 ## Installation
 
-> **Warning**: the `rootCA-key.pem` file that mkcert automatically generates gives complete power to intercept secure requests from your machine. Do not share it.
+> **Warning**: the `rootCA.key` file that mkcert automatically generates gives complete power to intercept secure requests from your machine. Do not share it.
 
 ### macOS
 
@@ -144,7 +144,7 @@ To only install the local root CA into a subset of them, you can set the `TRUST_
 
 ### Mobile devices
 
-For the certificates to be trusted on mobile devices, you will have to install the root CA. It's the `rootCA.pem` file in the folder printed by `mkcert -CAROOT`.
+For the certificates to be trusted on mobile devices, you will have to install the root CA. It's the `rootCA.crt` file in the folder printed by `mkcert -CAROOT`.
 
 On iOS, you can either use AirDrop, email the CA to yourself, or serve it from an HTTP server. After installing it, you must [enable full trust in it](https://support.apple.com/en-nz/HT204477). **Note**: earlier versions of mkcert ran into [an iOS bug](https://forums.developer.apple.com/thread/89568), if you can't see the root in "Certificate Trust Settings" you might have to update mkcert and [regenerate the root](https://github.com/FiloSottile/mkcert/issues/47#issuecomment-408724149).
 
@@ -155,7 +155,7 @@ For Android, you will have to install the CA and then enable user roots in the d
 Node does not use the system root store, so it won't accept mkcert certificates automatically. Instead, you will have to set the [`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#cli_node_extra_ca_certs_file) environment variable.
 
 ```
-export NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.pem"
+export NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.crt"
 ```
 
 ### Changing the location of the CA files
@@ -168,9 +168,9 @@ If you want to manage separate CAs, you can use the environment variable `$CAROO
 
 Installing in the trust store does not require the CA key, so you can export the CA certificate and use mkcert to install it in other machines.
 
-* Look for the `rootCA.pem` file in `mkcert -CAROOT`
+* Look for the `rootCA.crt` file in `mkcert -CAROOT`
 * copy it to a different machine
 * set `$CAROOT` to its directory
 * run `mkcert -install`
 
-Remember that mkcert is meant for development purposes, not production, so it should not be used on end users' machines, and that you should *not* export or share `rootCA-key.pem`.
+Remember that mkcert is meant for development purposes, not production, so it should not be used on end users' machines, and that you should *not* export or share `rootCA.key`.

--- a/cert.go
+++ b/cert.go
@@ -43,7 +43,7 @@ func init() {
 
 func (m *mkcert) makeCert(hosts []string) {
 	if m.caKey == nil {
-		log.Fatalln("ERROR: can't create new certificates because the CA key (rootCA-key.pem) is missing")
+		log.Fatalln("ERROR: can't create new certificates because the CA key (rootCA.key) is missing")
 	}
 
 	priv, err := m.generateKey(false)
@@ -152,11 +152,11 @@ func (m *mkcert) fileNames(hosts []string) (certFile, keyFile, p12File string) {
 		defaultName += "-client"
 	}
 
-	certFile = "./" + defaultName + ".pem"
+	certFile = "./" + defaultName + ".crt"
 	if m.certFile != "" {
 		certFile = m.certFile
 	}
-	keyFile = "./" + defaultName + "-key.pem"
+	keyFile = "./" + defaultName + ".key"
 	if m.keyFile != "" {
 		keyFile = m.keyFile
 	}
@@ -177,7 +177,7 @@ func randomSerialNumber() *big.Int {
 
 func (m *mkcert) makeCertFromCSR() {
 	if m.caKey == nil {
-		log.Fatalln("ERROR: can't create new certificates because the CA key (rootCA-key.pem) is missing")
+		log.Fatalln("ERROR: can't create new certificates because the CA key (rootCA.key) is missing")
 	}
 
 	csrPEMBytes, err := ioutil.ReadFile(m.csrPath)

--- a/main.go
+++ b/main.go
@@ -27,13 +27,13 @@ const shortUsage = `Usage of mkcert:
 	Install the local CA in the system trust store.
 
 	$ mkcert example.org
-	Generate "example.org.pem" and "example.org-key.pem".
+	Generate "example.org.crt" and "example.org.key".
 
 	$ mkcert example.com myapp.dev localhost 127.0.0.1 ::1
-	Generate "example.com+4.pem" and "example.com+4-key.pem".
+	Generate "example.com+4.crt" and "example.com+4.key".
 
 	$ mkcert "*.example.it"
-	Generate "_wildcard.example.it.pem" and "_wildcard.example.it-key.pem".
+	Generate "_wildcard.example.it.crt" and "_wildcard.example.it.key".
 
 	$ mkcert -uninstall
 	Uninstall the local CA (but do not delete it).
@@ -121,8 +121,8 @@ func main() {
 	}).Run(flag.Args())
 }
 
-const rootName = "rootCA.pem"
-const rootKeyName = "rootCA-key.pem"
+const rootName = "rootCA.crt"
+const rootKeyName = "rootCA.key"
 
 type mkcert struct {
 	installMode, uninstallMode bool


### PR DESCRIPTION
The `*.crt` file extension are associated with Crypto Shell Extensions in Windows. So leave the extension to `*.crt` might be better for cross platform friendly.

Changes:

- `*-key.pem` --> `*.key`
- `*.pem` --> `*.crt`

