### PR TITLE
Change u.Username to u.Name for more readibility

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -35,7 +35,11 @@ var userAndHostname string
 func init() {
 	u, _ := user.Current()
 	if u != nil {
-		userAndHostname = u.Name + "@"
+		var username = u.Name
+		if username == "" {
+			username = u.Username
+		}
+		userAndHostname = username + "@"
 	}
 	hostname, _ := os.Hostname()
 	userAndHostname += hostname

--- a/cert.go
+++ b/cert.go
@@ -35,7 +35,7 @@ var userAndHostname string
 func init() {
 	u, _ := user.Current()
 	if u != nil {
-		userAndHostname = u.Username + "@"
+		userAndHostname = u.Name + "@"
 	}
 	hostname, _ := os.Hostname()
 	userAndHostname += hostname


### PR DESCRIPTION
Use the `u.User` might be better than just use `u.Username`.  It because the `userAndHostname` used in **CommonName** and **OrganizationalUnit** field of the certificate.