### PR TITLE
Allow email SANs for S/MIME certificates

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -68,8 +68,8 @@ func (m *mkcert) makeCert(hosts []string) {
 	for _, h := range hosts {
 		if ip := net.ParseIP(h); ip != nil {
 			tpl.IPAddresses = append(tpl.IPAddresses, ip)
-		} else if email, err := mail.ParseAddress(h); err == nil {
-			tpl.EmailAddresses = append(tpl.EmailAddresses, email.Address)
+		} else if email, err := mail.ParseAddress(h); err == nil && email.Address == h {
+			tpl.EmailAddresses = append(tpl.EmailAddresses, h)
 		} else {
 			tpl.DNSNames = append(tpl.DNSNames, h)
 		}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/mail"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -190,13 +191,17 @@ func (m *mkcert) Run(args []string) {
 		if ip := net.ParseIP(name); ip != nil {
 			continue
 		}
+		if email, err := mail.ParseAddress(name); err == nil {
+			args[i] = email.Address
+			continue
+		}
 		punycode, err := idna.ToASCII(name)
 		if err != nil {
-			log.Fatalf("ERROR: %q is not a valid hostname or IP: %s", name, err)
+			log.Fatalf("ERROR: %q is not a valid hostname, IP, or email: %s", name, err)
 		}
 		args[i] = punycode
 		if !hostnameRegexp.MatchString(punycode) {
-			log.Fatalf("ERROR: %q is not a valid hostname or IP", name)
+			log.Fatalf("ERROR: %q is not a valid hostname, IP, or email", name)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -191,8 +191,7 @@ func (m *mkcert) Run(args []string) {
 		if ip := net.ParseIP(name); ip != nil {
 			continue
 		}
-		if email, err := mail.ParseAddress(name); err == nil {
-			args[i] = email.Address
+		if email, err := mail.ParseAddress(name); err == nil && email.Address == name {
 			continue
 		}
 		punycode, err := idna.ToASCII(name)


### PR DESCRIPTION
This PR allows email addresses to be passed in, along with IP addresses and domain names. Email addresses are added as SANs. The appropriate EKUs are added to the cert based on which types of SANs are present. To identify email addresses, I try parsing them with the `net/mail` package. This is probably overkill and I'm happy to switch to a regex if that's preferrable.



/fixes https://github.com/FiloSottile/mkcert/issues/143
/cc @jcjones