### PR TITLE
Add support for certificates with client and server auth and URL SANs

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"net"
 	"net/mail"
+	"net/url"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -70,6 +71,8 @@ func (m *mkcert) makeCert(hosts []string) {
 			tpl.IPAddresses = append(tpl.IPAddresses, ip)
 		} else if email, err := mail.ParseAddress(h); err == nil && email.Address == h {
 			tpl.EmailAddresses = append(tpl.EmailAddresses, h)
+		} else if uriName, err := url.Parse(h); err == nil && uriName.Scheme != "" {
+			tpl.URIs = append(tpl.URIs, uriName)
 		} else {
 			tpl.DNSNames = append(tpl.DNSNames, h)
 		}

--- a/cert.go
+++ b/cert.go
@@ -71,7 +71,7 @@ func (m *mkcert) makeCert(hosts []string) {
 			tpl.IPAddresses = append(tpl.IPAddresses, ip)
 		} else if email, err := mail.ParseAddress(h); err == nil && email.Address == h {
 			tpl.EmailAddresses = append(tpl.EmailAddresses, h)
-		} else if uriName, err := url.Parse(h); err == nil && uriName.Scheme != "" {
+		} else if uriName, err := url.Parse(h); err == nil && uriName.Scheme == "spiffe" {
 			tpl.URIs = append(tpl.URIs, uriName)
 		} else {
 			tpl.DNSNames = append(tpl.DNSNames, h)

--- a/cert.go
+++ b/cert.go
@@ -79,7 +79,7 @@ func (m *mkcert) makeCert(hosts []string) {
 	}
 
 	if m.client {
-		tpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+		tpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
 	} else if len(tpl.IPAddresses) > 0 || len(tpl.DNSNames) > 0 {
 		tpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
 	}

--- a/cert.go
+++ b/cert.go
@@ -71,7 +71,7 @@ func (m *mkcert) makeCert(hosts []string) {
 			tpl.IPAddresses = append(tpl.IPAddresses, ip)
 		} else if email, err := mail.ParseAddress(h); err == nil && email.Address == h {
 			tpl.EmailAddresses = append(tpl.EmailAddresses, h)
-		} else if uriName, err := url.Parse(h); err == nil && uriName.Scheme == "spiffe" {
+		} else if uriName, err := url.Parse(h); err == nil && uriName.Scheme != "" && uriName.Host != "" {
 			tpl.URIs = append(tpl.URIs, uriName)
 		} else {
 			tpl.DNSNames = append(tpl.DNSNames, h)

--- a/main.go
+++ b/main.go
@@ -200,7 +200,7 @@ func (m *mkcert) Run(args []string) {
 		}
 		punycode, err := idna.ToASCII(name)
 		if err != nil {
-			log.Fatalf("ERROR: %q is not a valid hostname, IP, spiffe URI or email: %s", name, err)
+			log.Fatalf("ERROR: %q is not a valid hostname, IP, URL or email: %s", name, err)
 		}
 		args[i] = punycode
 		if !hostnameRegexp.MatchString(punycode) {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"net"
 	"net/mail"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -192,6 +193,9 @@ func (m *mkcert) Run(args []string) {
 			continue
 		}
 		if email, err := mail.ParseAddress(name); err == nil && email.Address == name {
+			continue
+		}
+		if _, err := url.Parse(name); err == nil {
 			continue
 		}
 		punycode, err := idna.ToASCII(name)

--- a/main.go
+++ b/main.go
@@ -204,7 +204,7 @@ func (m *mkcert) Run(args []string) {
 		}
 		args[i] = punycode
 		if !hostnameRegexp.MatchString(punycode) {
-			log.Fatalf("ERROR: %q is not a valid hostname, IP, spiffe URI or email", name)
+			log.Fatalf("ERROR: %q is not a valid hostname, IP, URL or email", name)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -195,7 +195,7 @@ func (m *mkcert) Run(args []string) {
 		if email, err := mail.ParseAddress(name); err == nil && email.Address == name {
 			continue
 		}
-		if uriName, err := url.Parse(name); err == nil && uriName.Scheme == "spiffe" {
+		if uriName, err := url.Parse(name); err == nil && uriName.Scheme != "" && uriName.Host != "" {
 			continue
 		}
 		punycode, err := idna.ToASCII(name)

--- a/main.go
+++ b/main.go
@@ -195,16 +195,16 @@ func (m *mkcert) Run(args []string) {
 		if email, err := mail.ParseAddress(name); err == nil && email.Address == name {
 			continue
 		}
-		if _, err := url.Parse(name); err == nil {
+		if uriName, err := url.Parse(name); err == nil && uriName.Scheme == "spiffe" {
 			continue
 		}
 		punycode, err := idna.ToASCII(name)
 		if err != nil {
-			log.Fatalf("ERROR: %q is not a valid hostname, IP, or email: %s", name, err)
+			log.Fatalf("ERROR: %q is not a valid hostname, IP, spiffe URI or email: %s", name, err)
 		}
 		args[i] = punycode
 		if !hostnameRegexp.MatchString(punycode) {
-			log.Fatalf("ERROR: %q is not a valid hostname, IP, or email", name)
+			log.Fatalf("ERROR: %q is not a valid hostname, IP, spiffe URI or email", name)
 		}
 	}
 


### PR DESCRIPTION
Thank you for this awesome tool! :-)

I wanted to use it to create certificates for a Service Mesh, that is for using Istio with mTLS without using Citadel.
Therefore I needed to create certificates that have an extended key usage of client and server auth.
I also needed to have Spiffe URIs in the Subject Alternate Names.

Therefore I did the following changes:
1. Add a new flag `-server` which is enabled by default. If set to `false` and setting `-client=true` a client-only certificate would be generated, with `-client=true`  and `-server=true` (the default) a client and server certificate would be created.
2. Check the hostnames for being a URI with a non-empty scheme. In that case the name is accepted and added as a URI SAN.