### PR TITLE
README: use $GOBIN instead of $GOPATH/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ or build from source (requires Go 1.10+)
 
 ```
 go get -u github.com/FiloSottile/mkcert
-$(go env GOPATH)/bin/mkcert
+$(go env GOBIN)/mkcert
 ```
 
 or use [the pre-built binaries](https://github.com/FiloSottile/mkcert/releases).


### PR DESCRIPTION
$GOPATH/bin works in the simple cases, but will break if the user
specifies their own $GOBIN, or if their $GOPATH has multiple elements.

This form is also simpler. Even if the user doesn't specify their custom
$GOBIN, 'go env GOBIN' will return the correct default.