### PR TITLE
Make shorter certificate duration for catalina requirements, closes #174

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -63,14 +63,16 @@ func (m *mkcert) makeCert(hosts []string) {
 			OrganizationalUnit: []string{userAndHostname},
 		},
 
-		NotAfter:  time.Now().AddDate(10, 0, 0),
 
-		// Fix the notBefore to temporarily bypass macOS Catalina's limit on
-		// certificate lifespan. Once mkcert provides an ACME server, automation
+		// macOS Catalina requires a lifespan for cert of less than 825 days.
+		// Set NotBefore to yesterday
+		// Set NotAfter to 823 days from today
+		// Once mkcert provides an ACME server, automation
 		// will be the recommended way to guarantee uninterrupted functionality,
 		// and the lifespan will be shortened to 825 days. See issue 174 and
 		// https://support.apple.com/en-us/HT210176.
-		NotBefore: time.Date(2019, time.June, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:  time.Now().AddDate(0, 0, 823),
+		NotBefore: time.Now().AddDate(0,0,-1),
 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		BasicConstraintsValid: true,


### PR DESCRIPTION
Based on the discussion in #174, "Certificate is not standards-compliant in Catalina"  this PR 
* Sets the start date to yesterday
* Sets the valid end date 823 days out. 

I think this is probably better in general than the approach in current master, which just pre-dates the cert to before June, since it probably deals with the actual requirement of the standard. 