### PR TITLE
Use regexp compile

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -137,7 +137,10 @@ func (m *mkcert) makeCert(hosts []string) {
 }
 
 func (m *mkcert) printHosts(hosts []string) {
-	secondLvlWildcardRegexp := regexp.MustCompile(`(?i)^\*\.[0-9a-z_-]+$`)
+	secondLvlWildcardRegexp, err = regexp.Compile(`(?i)^\*\.[0-9a-z_-]+$`)
+	if err != nil {
+		log.Fatalf("Error: Regex failed to compile - %s", err)
+	}
 	log.Printf("\nCreated a new certificate valid for the following names 📜")
 	for _, h := range hosts {
 		log.Printf(" - %q", h)

--- a/cert.go
+++ b/cert.go
@@ -33,8 +33,10 @@ import (
 )
 
 var userAndHostname string
+var secondLvlWildcardRegexp *regexp.Regexp
 
 func init() {
+	secondLvlWildcardRegexp = regexp.MustCompile(`(?i)^\*\.[0-9a-z_-]+$`)
 	u, err := user.Current()
 	if err == nil {
 		userAndHostname = u.Username + "@"
@@ -137,10 +139,6 @@ func (m *mkcert) makeCert(hosts []string) {
 }
 
 func (m *mkcert) printHosts(hosts []string) {
-	secondLvlWildcardRegexp, err := regexp.Compile(`(?i)^\*\.[0-9a-z_-]+$`)
-	if err != nil {
-		log.Fatalf("Error: Regex failed to compile - %s", err)
-	}
 	log.Printf("\nCreated a new certificate valid for the following names 📜")
 	for _, h := range hosts {
 		log.Printf(" - %q", h)

--- a/cert.go
+++ b/cert.go
@@ -137,7 +137,7 @@ func (m *mkcert) makeCert(hosts []string) {
 }
 
 func (m *mkcert) printHosts(hosts []string) {
-	secondLvlWildcardRegexp, err = regexp.Compile(`(?i)^\*\.[0-9a-z_-]+$`)
+	secondLvlWildcardRegexp, err := regexp.Compile(`(?i)^\*\.[0-9a-z_-]+$`)
 	if err != nil {
 		log.Fatalf("Error: Regex failed to compile - %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -78,7 +78,10 @@ const advancedUsage = `Advanced options:
 
 `
 
+var hostnameRegexp *regexp.Regexp
+
 func main() {
+	hostnameRegexp = regexp.MustCompile(`(?i)^(\*\.)?[0-9a-z_-]([0-9a-z._-]*[0-9a-z_-])?$`)
 	log.SetFlags(0)
 	var (
 		installFlag   = flag.Bool("install", false, "")
@@ -190,10 +193,6 @@ func (m *mkcert) Run(args []string) {
 		return
 	}
 
-	hostnameRegexp, err := regexp.Compile(`(?i)^(\*\.)?[0-9a-z_-]([0-9a-z._-]*[0-9a-z_-])?$`)
-	if err != nil {
-		log.Fatalf("Error: Regex failed to compile - %s", err)
-	}
 	for i, name := range args {
 		if ip := net.ParseIP(name); ip != nil {
 			continue

--- a/main.go
+++ b/main.go
@@ -190,7 +190,10 @@ func (m *mkcert) Run(args []string) {
 		return
 	}
 
-	hostnameRegexp := regexp.MustCompile(`(?i)^(\*\.)?[0-9a-z_-]([0-9a-z._-]*[0-9a-z_-])?$`)
+	hostnameRegexp, err := regexp.Compile(`(?i)^(\*\.)?[0-9a-z_-]([0-9a-z._-]*[0-9a-z_-])?$`)
+	if err != nil {
+		log.Fatalf("Error: Regex failed to compile - %s", err)
+	}
 	for i, name := range args {
 		if ip := net.ParseIP(name); ip != nil {
 			continue


### PR DESCRIPTION
The [regexp.MustCompile function](https://golang.org/pkg/regexp/#MustCompile) panics if the regex fails to compile and should only be used in globals or init functions. Instead use [regexp.Compile](https://golang.org/pkg/regexp/#Compile) and check `err` is nil.