### PR TITLE
Add note about advanced options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ To only install the local root CA into a subset of them, you can set the `TRUST_
 	    all other flags and arguments except -install and -cert-file.
 ```
 
+> **Note:** You _must_ place this options before the domain names list.
+
+**Example:**
+
+```bash
+mkcert -key-file ./my.key -cert-file ./my.cert  local.app *.local.app
+```
+
+
+
 ### S/MIME
 
 mkcert automatically generates an S/MIME certificate if one of the supplied names is an email address.

--- a/README.md
+++ b/README.md
@@ -144,15 +144,13 @@ To only install the local root CA into a subset of them, you can set the `TRUST_
 	    all other flags and arguments except -install and -cert-file.
 ```
 
-> **Note:** You _must_ place this options before the domain names list.
+> **Note:** You _must_ place these options before the domain names list.
 
-**Example:**
+#### Example
 
-```bash
-mkcert -key-file ./my.key -cert-file ./my.cert  local.app *.local.app
 ```
-
-
+mkcert -key-file key.pem -cert-file cert.pem example.com *.example.com
+```
 
 ### S/MIME
 


### PR DESCRIPTION
Clarify position of advanced options argumnts (they won’t work if are placed after domain names)

Add example.