### PR TITLE
Refactor truststore logic into own package (1/2)

### DIFF
--- a/truststore/truststore.go
+++ b/truststore/truststore.go
@@ -1,0 +1,47 @@
+// Package truststore adds and removes certificates from the system truststore.
+package truststore
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"os/user"
+	"sync"
+)
+
+// Installer installs a certificate to the system truststore.
+type Installer struct{}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func binaryExists(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+var sudoWarningOnce sync.Once
+
+func commandWithSudo(cmd ...string) (*exec.Cmd, error) {
+	if u, err := user.Current(); err == nil && u.Uid == "0" {
+		return exec.Command(cmd[0], cmd[1:]...), nil
+	}
+	if !binaryExists("sudo") {
+		return nil, errors.New("sudo not available")
+	}
+	return exec.Command("sudo", append([]string{"--prompt=Sudo password:", "--"}, cmd...)...), nil
+}
+
+func decodeCert(path string) (*x509.Certificate, error) {
+	d, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	b, _ := pem.Decode(d)
+	return x509.ParseCertificate(b.Bytes)
+}

--- a/truststore/truststore.go
+++ b/truststore/truststore.go
@@ -1,4 +1,4 @@
-// Package truststore adds and removes certificates from the system truststore.
+// Package truststore adds and removes certificates from system truststores.
 package truststore
 
 import (
@@ -13,10 +13,12 @@ import (
 	"sync"
 )
 
-// Truststore installs, uninstalls, & enumerates certificates on the store.
+// Truststore represents a store of root certificates on the system.
 type Truststore interface {
 	// Install installs the PEM-encoded certificate at path.
 	Install(path string) error
+	// Uninstall removes the PEM-encoded certificate at path.
+	Uninstall(path string) error
 }
 
 func pathExists(path string) bool {

--- a/truststore/truststore.go
+++ b/truststore/truststore.go
@@ -9,11 +9,15 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"runtime"
 	"sync"
 )
 
-// Installer installs a certificate to the system truststore.
-type Installer struct{}
+// Truststore installs, uninstalls, & enumerates certificates on the store.
+type Truststore interface {
+	// Install installs the PEM-encoded certificate at path.
+	Install(path string) error
+}
 
 func pathExists(path string) bool {
 	_, err := os.Stat(path)
@@ -44,4 +48,17 @@ func decodeCert(path string) (*x509.Certificate, error) {
 	}
 	b, _ := pem.Decode(d)
 	return x509.ParseCertificate(b.Bytes)
+}
+
+func firefoxProfile() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return os.Getenv("HOME") + "/Library/Application Support/Firefox/Profiles/*"
+	case "linux":
+		return os.Getenv("HOME") + "/.mozilla/firefox/*"
+	case "windows":
+		return os.Getenv("USERPROFILE") + "\\AppData\\Roaming\\Mozilla\\Firefox\\Profiles"
+	}
+
+	return ""
 }

--- a/truststore/truststore_darwin.go
+++ b/truststore/truststore_darwin.go
@@ -95,7 +95,7 @@ func updatePlatformTrustSettings(root map[string]interface{}) error {
 		return err
 	}
 	if _, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("command %q failed: %v", "trust-settings-import", err)
+		return fmt.Errorf("command %q failed: %v", "security trust-settings-import", err)
 	}
 	return nil
 }
@@ -138,4 +138,16 @@ func (i *darwinStore) Install(path string) error {
 		break
 	}
 	return updatePlatformTrustSettings(plistRoot)
+}
+
+// Uninstall removes the PEM-encoded certificate at path from the system store.
+func (i *darwinStore) Uninstall(path string) error {
+	cmd, err := commandWithSudo("security", "remove-trusted-cert", "-d", path)
+	if err != nil {
+		return err
+	}
+	if _, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("command %q failed: %v", "security remove-trusted-cert", err)
+	}
+	return nil
 }

--- a/truststore/truststore_darwin.go
+++ b/truststore/truststore_darwin.go
@@ -1,0 +1,134 @@
+package truststore
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"howett.net/plist"
+)
+
+// https://github.com/golang/go/issues/24652#issuecomment-399826583
+var trustSettings []interface{}
+var _, _ = plist.Unmarshal(trustSettingsData, &trustSettings)
+var trustSettingsData = []byte(`
+<array>
+	<dict>
+		<key>kSecTrustSettingsPolicy</key>
+		<data>
+		KoZIhvdjZAED
+		</data>
+		<key>kSecTrustSettingsPolicyName</key>
+		<string>sslServer</string>
+		<key>kSecTrustSettingsResult</key>
+		<integer>1</integer>
+	</dict>
+	<dict>
+		<key>kSecTrustSettingsPolicy</key>
+		<data>
+		KoZIhvdjZAEC
+		</data>
+		<key>kSecTrustSettingsPolicyName</key>
+		<string>basicX509</string>
+		<key>kSecTrustSettingsResult</key>
+		<integer>1</integer>
+	</dict>
+</array>
+`)
+
+func platformTrustSettings() (map[string]interface{}, error) {
+	plistFile, err := ioutil.TempFile("", "trust-settings")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary file: %v", err)
+	}
+	defer os.Remove(plistFile.Name())
+
+	cmd, err := commandWithSudo("security", "trust-settings-export", "-d", plistFile.Name())
+	if err != nil {
+		return nil, err
+	}
+	if _, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("command %q failed: %v", "security trust-settings-export", err)
+	}
+
+	plistData, err := ioutil.ReadFile(plistFile.Name())
+	if err != nil {
+		return nil, fmt.Errorf("failed to read trust settings: %v", err)
+	}
+	var plistRoot map[string]interface{}
+	if _, err := plist.Unmarshal(plistData, &plistRoot); err != nil {
+		return nil, fmt.Errorf("failed to parse trust settings: %v", err)
+	}
+
+	if plistRoot["trustVersion"].(uint64) != 1 {
+		return nil, fmt.Errorf("unsupported trust settings version: %v", plistRoot["trustVersion"])
+	}
+	return plistRoot, nil
+}
+
+func updatePlatformTrustSettings(root map[string]interface{}) error {
+	plistFile, err := ioutil.TempFile("", "trust-settings")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file: %v", err)
+	}
+	defer os.Remove(plistFile.Name())
+
+	plistData, err := plist.MarshalIndent(root, plist.XMLFormat, "\t")
+	if err != nil {
+		return fmt.Errorf("failed to serialize trust settings: %v", err)
+	}
+	if err := ioutil.WriteFile(plistFile.Name(), plistData, 0600); err != nil {
+		return fmt.Errorf("failed to write trust settings: %v", err)
+	}
+
+	cmd, err := commandWithSudo("security", "trust-settings-import", "-d", plistFile.Name())
+	if err != nil {
+		return err
+	}
+	if _, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("command %q failed: %v", "trust-settings-import", err)
+	}
+	return nil
+}
+
+// Install installs the pem-encoded root certificate at the provided path
+// to the system store.
+func (i *Installer) Install(path string) error {
+	cert, err := decodeCert(path)
+	if err != nil {
+		return err
+	}
+	cmd, err := commandWithSudo("security", "add-trusted-cert", "-d", "-k", "/Library/Keychains/System.keychain", path)
+	if err != nil {
+		return err
+	}
+	if _, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("command %q failed: %v", "security add-trusted-cert", err)
+	}
+
+	// Make trustSettings explicit, as older Go does not know the defaults.
+	// https://github.com/golang/go/issues/24652
+	plistRoot, err := platformTrustSettings()
+	if err != nil {
+		return err
+	}
+	rootSubjectASN1, _ := asn1.Marshal(cert.Subject.ToRDNSequence())
+	// Update the trust settings to our defaults for any key which has the
+	// same subject as our new cert,
+	trustList := plistRoot["trustList"].(map[string]interface{})
+	for key := range trustList {
+		entry := trustList[key].(map[string]interface{})
+		if _, ok := entry["issuerName"]; !ok {
+			continue
+		}
+		issuerName := entry["issuerName"].([]byte)
+		if !bytes.Equal(rootSubjectASN1, issuerName) {
+			continue
+		}
+		entry["trustSettings"] = trustSettings
+		break
+	}
+	return updatePlatformTrustSettings(plistRoot)
+}

--- a/truststore/truststore_darwin.go
+++ b/truststore/truststore_darwin.go
@@ -38,6 +38,13 @@ var trustSettingsData = []byte(`
 </array>
 `)
 
+type darwinStore struct{}
+
+// Platform returns the truststore for the current platform.
+func Platform() (Truststore, error) {
+	return &darwinStore{}, nil
+}
+
 func platformTrustSettings() (map[string]interface{}, error) {
 	plistFile, err := ioutil.TempFile("", "trust-settings")
 	if err != nil {
@@ -95,7 +102,7 @@ func updatePlatformTrustSettings(root map[string]interface{}) error {
 
 // Install installs the pem-encoded root certificate at the provided path
 // to the system store.
-func (i *Installer) Install(path string) error {
+func (i *darwinStore) Install(path string) error {
 	cert, err := decodeCert(path)
 	if err != nil {
 		return err

--- a/truststore/truststore_java.go
+++ b/truststore/truststore_java.go
@@ -1,0 +1,98 @@
+package truststore
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const storePass string = "changeit"
+
+type javaTruststore struct {
+	javaHome    string
+	cacertsPath string
+	keytoolPath string
+}
+
+// Java returns the truststore used by Java.
+func Java() (Truststore, error) {
+	var (
+		javaHome    string
+		cacertsPath string
+		keytoolPath string
+	)
+
+	if runtime.GOOS == "windows" {
+		keytoolPath = filepath.Join("bin", "keytool.exe")
+	} else {
+		keytoolPath = filepath.Join("bin", "keytool")
+	}
+
+	javaHome = os.Getenv("JAVA_HOME")
+	if javaHome == "" {
+		return nil, errors.New("could not determine JAVA_HOME")
+	}
+	if !pathExists(filepath.Join(javaHome, keytoolPath)) {
+		return nil, fmt.Errorf("JAVA_HOME/%s not present", keytoolPath)
+	}
+	keytoolPath = filepath.Join(javaHome, keytoolPath)
+
+	if pathExists(filepath.Join(javaHome, "lib", "security", "cacerts")) {
+		cacertsPath = filepath.Join(javaHome, "lib", "security", "cacerts")
+	}
+	if pathExists(filepath.Join(javaHome, "jre", "lib", "security", "cacerts")) {
+		cacertsPath = filepath.Join(javaHome, "jre", "lib", "security", "cacerts")
+	}
+
+	return &javaTruststore{
+		cacertsPath: cacertsPath,
+		javaHome:    javaHome,
+		keytoolPath: keytoolPath,
+	}, nil
+}
+
+// Install installs the pem-encoded root certificate at the provided path
+// to the Java trust store.
+func (j *javaTruststore) Install(path string) error {
+	c, err := decodeCert(path)
+	if err != nil {
+		return fmt.Errorf("failed to parse root certificate: %v", err)
+	}
+
+	_, err = j.execKeytool(
+		"-importcert", "-noprompt",
+		"-keystore", j.cacertsPath,
+		"-storepass", storePass,
+		"-file", path,
+		"-alias", strings.Replace("mkcert development CA "+c.SerialNumber.String(), " ", "_", -1),
+	)
+	if err != nil {
+		return fmt.Errorf("command %q failed: %v", "keytool -import", err)
+	}
+	return nil
+}
+
+// execKeytool will execute a "keytool" command and if needed re-execute
+// the command with commandWithSudo to work around file permissions.
+func (j *javaTruststore) execKeytool(args ...string) ([]byte, error) {
+	cmd := exec.Command(j.keytoolPath, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil && bytes.Contains(out, []byte("java.io.FileNotFoundException")) && runtime.GOOS != "windows" {
+		origArgs := cmd.Args[1:]
+		cmd, err = commandWithSudo(cmd.Path)
+		if err != nil {
+			return nil, err
+		}
+		cmd.Args = append(cmd.Args, origArgs...)
+		cmd.Env = []string{
+			"JAVA_HOME=" + j.javaHome,
+		}
+		out, err = cmd.CombinedOutput()
+	}
+	return out, err
+}

--- a/truststore/truststore_linux.go
+++ b/truststore/truststore_linux.go
@@ -8,6 +8,13 @@ import (
 	"strings"
 )
 
+type linuxStore struct{}
+
+// Platform returns the truststore for the current platform.
+func Platform() (Truststore, error) {
+	return &linuxStore{}, nil
+}
+
 // installCommand describes the command necessary to install
 // a root certificate on the current platform.
 type installCommand struct {
@@ -43,7 +50,7 @@ func installStrategy() (installCommand, error) {
 
 // Install installs the pem-encoded root certificate at the provided path
 // to the system store.
-func (i *Installer) Install(path string) error {
+func (i *linuxStore) Install(path string) error {
 	pemData, err := ioutil.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to read root certificate: %v", err)
@@ -62,14 +69,14 @@ func (i *Installer) Install(path string) error {
 		return err
 	}
 	cmd.Stdin = bytes.NewReader(pemData)
-  if _, err := cmd.CombinedOutput(); err != nil {
+	if _, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("command %q failed: %v", "tee", err)
 	}
 
 	cmd, err = commandWithSudo(strategy.command...)
-  if err != nil {
-    return err
-  }
+	if err != nil {
+		return err
+	}
 	if _, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("command %q failed: %v", strings.Join(strategy.command, " "), err)
 	}

--- a/truststore/truststore_linux.go
+++ b/truststore/truststore_linux.go
@@ -1,0 +1,77 @@
+package truststore
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+// installCommand describes the command necessary to install
+// a root certificate on the current platform.
+type installCommand struct {
+	rootsPattern string
+	command      []string
+}
+
+func installStrategy() (installCommand, error) {
+	if pathExists("/etc/pki/ca-trust/source/anchors/") {
+		return installCommand{
+			rootsPattern: "/etc/pki/ca-trust/source/anchors/%s.pem",
+			command:      []string{"update-ca-trust", "extract"},
+		}, nil
+	} else if pathExists("/usr/local/share/ca-certificates/") {
+		return installCommand{
+			rootsPattern: "/usr/local/share/ca-certificates/%s.crt",
+			command:      []string{"update-ca-certificates"},
+		}, nil
+	} else if pathExists("/etc/ca-certificates/trust-source/anchors/") {
+		return installCommand{
+			rootsPattern: "/etc/ca-certificates/trust-source/anchors/%s.crt",
+			command:      []string{"trust", "extract-compat"},
+		}, nil
+	} else if pathExists("/usr/share/pki/trust/anchors") {
+		return installCommand{
+			rootsPattern: "/usr/share/pki/trust/anchors/%s.pem",
+			command:      []string{"update-ca-certificates"},
+		}, nil
+	}
+
+	return installCommand{}, errors.New("no install strategy available")
+}
+
+// Install installs the pem-encoded root certificate at the provided path
+// to the system store.
+func (i *Installer) Install(path string) error {
+	pemData, err := ioutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read root certificate: %v", err)
+	}
+	c, err := decodeCert(path)
+	if err != nil {
+		return fmt.Errorf("failed to parse root certificate: %v", err)
+	}
+	strategy, err := installStrategy()
+	if err != nil {
+		return err
+	}
+
+	cmd, err := commandWithSudo("tee", fmt.Sprintf(strategy.rootsPattern, strings.Replace("mkcert development CA "+c.SerialNumber.String(), " ", "_", -1)))
+	if err != nil {
+		return err
+	}
+	cmd.Stdin = bytes.NewReader(pemData)
+  if _, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("command %q failed: %v", "tee", err)
+	}
+
+	cmd, err = commandWithSudo(strategy.command...)
+  if err != nil {
+    return err
+  }
+	if _, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("command %q failed: %v", strings.Join(strategy.command, " "), err)
+	}
+	return nil
+}

--- a/truststore/truststore_nss.go
+++ b/truststore/truststore_nss.go
@@ -1,0 +1,146 @@
+package truststore
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var (
+	nssDBs = []string{
+		filepath.Join(os.Getenv("HOME"), ".pki/nssdb"),
+		filepath.Join(os.Getenv("HOME"), "snap/chromium/current/.pki/nssdb"), // Snapcraft
+		"/etc/pki/nssdb", // CentOS 7
+	}
+	firefoxPaths = []string{
+		"/usr/bin/firefox", "/Applications/Firefox.app",
+		"/Applications/Firefox Developer Edition.app",
+		"/Applications/Firefox Nightly.app",
+		"C:\\Program Files\\Mozilla Firefox",
+	}
+)
+
+type nss struct {
+	certutilPath string
+}
+
+func (n *nss) Install(path string) error {
+	c, err := decodeCert(path)
+	if err != nil {
+		return fmt.Errorf("failed to parse root certificate: %v", err)
+	}
+	uniqueName := strings.Replace("mkcert development CA "+c.SerialNumber.String(), " ", "_", -1)
+
+	found, err := n.forEachNSSProfile(func(profile string) error {
+		if _, err := n.execCertutil("-A", "-d", profile, "-t", "C,,", "-n", uniqueName, "-i", path); err != nil {
+			return fmt.Errorf("command %q failed: %v", "certutil -A -d "+profile, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if found == 0 {
+		return errors.New("no NSS databases found")
+	}
+
+	return nil
+}
+
+// certutilPath returns an absolute path to the certutil binary, or
+// the empty string if the binary was not found.
+func certutilPath() string {
+	switch runtime.GOOS {
+	case "darwin":
+		switch {
+		case binaryExists("certutil"):
+			p, _ := exec.LookPath("certutil")
+			return p
+		case binaryExists("/usr/local/opt/nss/bin/certutil"):
+			// Check the default Homebrew path, to save executing Ruby. #135
+			return "/usr/local/opt/nss/bin/certutil"
+		default:
+			out, err := exec.Command("brew", "--prefix", "nss").Output()
+			if err == nil {
+				certutilPath := filepath.Join(strings.TrimSpace(string(out)), "bin", "certutil")
+				if pathExists(certutilPath) {
+					return certutilPath
+				}
+			}
+		}
+
+	case "linux":
+		if binaryExists("certutil") {
+			p, _ := exec.LookPath("certutil")
+			return p
+		}
+	}
+
+	return ""
+}
+
+func usesNSS() bool {
+	for _, path := range append(append([]string{}, nssDBs...), firefoxPaths...) {
+		if pathExists(path) {
+			return true
+		}
+	}
+	return false
+}
+
+// NSS returns the truststore used by NSS.
+func NSS() (Truststore, error) {
+	if !usesNSS() {
+		return nil, errors.New("no NSS-compatible application or database")
+	}
+	certutilPath := certutilPath()
+	if certutilPath == "" {
+		return nil, errors.New("certutil binary not found")
+	}
+
+	return &nss{certutilPath: certutilPath}, nil
+}
+
+func (n *nss) forEachNSSProfile(f func(profile string) error) (found int, err error) {
+	profiles, _ := filepath.Glob(firefoxProfile())
+	profiles = append(profiles, nssDBs...)
+	for _, profile := range profiles {
+		if stat, err := os.Stat(profile); err != nil || !stat.IsDir() {
+			continue
+		}
+		if pathExists(filepath.Join(profile, "cert9.db")) {
+			if err := f("sql:" + profile); err != nil {
+				return 0, err
+			}
+			found++
+		} else if pathExists(filepath.Join(profile, "cert8.db")) {
+			if err := f("dbm:" + profile); err != nil {
+				return 0, err
+			}
+			found++
+		}
+	}
+	return found, nil
+}
+
+// execCertutil will execute a "execCertutil" command and if needed re-execute
+// the command with commandWithSudo to work around file permissions.
+func (n *nss) execCertutil(args ...string) ([]byte, error) {
+	cmd := exec.Command(n.certutilPath, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil && bytes.Contains(out, []byte("SEC_ERROR_READ_ONLY")) && runtime.GOOS != "windows" {
+		origArgs := cmd.Args[1:]
+		cmd, err = commandWithSudo(cmd.Path)
+		if err != nil {
+			return nil, err
+		}
+		cmd.Args = append(cmd.Args, origArgs...)
+		out, err = cmd.CombinedOutput()
+	}
+	return out, err
+}

--- a/truststore/truststore_windows.go
+++ b/truststore/truststore_windows.go
@@ -1,0 +1,108 @@
+package truststore
+
+import (
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modcrypt32                           = syscall.NewLazyDLL("crypt32.dll")
+	procCertAddEncodedCertificateToStore = modcrypt32.NewProc("CertAddEncodedCertificateToStore")
+	procCertCloseStore                   = modcrypt32.NewProc("CertCloseStore")
+	procCertDeleteCertificateFromStore   = modcrypt32.NewProc("CertDeleteCertificateFromStore")
+	procCertDuplicateCertificateContext  = modcrypt32.NewProc("CertDuplicateCertificateContext")
+	procCertEnumCertificatesInStore      = modcrypt32.NewProc("CertEnumCertificatesInStore")
+	procCertOpenSystemStoreW             = modcrypt32.NewProc("CertOpenSystemStoreW")
+)
+
+type windowsTruststore struct{}
+
+// Platform returns the truststore for the current platform.
+func Platform() (Truststore, error) {
+	return &windowsTruststore{}, nil
+}
+
+// Install installs the pem-encoded root certificate at the provided path
+// to the system store.
+func (w *windowsTruststore) Install(path string) error {
+	cert, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	store, err := openWindowsRootStore()
+	if err != nil {
+		return fmt.Errorf("failed to open root store: %v", err)
+	}
+	defer store.close()
+	return store.addCert(cert)
+}
+
+type windowsRootStore uintptr
+
+func openWindowsRootStore() (windowsRootStore, error) {
+	store, _, err := procCertOpenSystemStoreW.Call(0, uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr("ROOT"))))
+	if store != 0 {
+		return windowsRootStore(store), nil
+	}
+	return 0, fmt.Errorf("Failed to open windows root store: %v", err)
+}
+
+func (w windowsRootStore) close() error {
+	ret, _, err := procCertCloseStore.Call(uintptr(w), 0)
+	if ret != 0 {
+		return nil
+	}
+	return fmt.Errorf("Failed to close windows root store: %v", err)
+}
+
+func (w windowsRootStore) addCert(cert []byte) error {
+	// TODO: ok to always overwrite?
+	ret, _, err := procCertAddEncodedCertificateToStore.Call(
+		uintptr(w), // HCERTSTORE hCertStore
+		uintptr(syscall.X509_ASN_ENCODING|syscall.PKCS_7_ASN_ENCODING), // DWORD dwCertEncodingType
+		uintptr(unsafe.Pointer(&cert[0])),                              // const BYTE *pbCertEncoded
+		uintptr(len(cert)),                                             // DWORD cbCertEncoded
+		3,                                                              // DWORD dwAddDisposition (CERT_STORE_ADD_REPLACE_EXISTING is 3)
+		0,                                                              // PCCERT_CONTEXT *ppCertContext
+	)
+	if ret != 0 {
+		return nil
+	}
+	return fmt.Errorf("Failed adding cert: %v", err)
+}
+
+func (w windowsRootStore) deleteCertsWithSerial(serial *big.Int) (bool, error) {
+	// Go over each, deleting the ones we find
+	var cert *syscall.CertContext
+	deletedAny := false
+	for {
+		// Next enum
+		certPtr, _, err := procCertEnumCertificatesInStore.Call(uintptr(w), uintptr(unsafe.Pointer(cert)))
+		if cert = (*syscall.CertContext)(unsafe.Pointer(certPtr)); cert == nil {
+			if errno, ok := err.(syscall.Errno); ok && errno == 0x80092004 {
+				break
+			}
+			return deletedAny, fmt.Errorf("Failed enumerating certs: %v", err)
+		}
+		// Parse cert
+		certBytes := (*[1 << 20]byte)(unsafe.Pointer(cert.EncodedCert))[:cert.Length]
+		parsedCert, err := x509.ParseCertificate(certBytes)
+		// We'll just ignore parse failures for now
+		if err == nil && parsedCert.SerialNumber != nil && parsedCert.SerialNumber.Cmp(serial) == 0 {
+			// Duplicate the context so it doesn't stop the enum when we delete it
+			dupCertPtr, _, err := procCertDuplicateCertificateContext.Call(uintptr(unsafe.Pointer(cert)))
+			if dupCertPtr == 0 {
+				return deletedAny, fmt.Errorf("Failed duplicating context: %v", err)
+			}
+			if ret, _, err := procCertDeleteCertificateFromStore.Call(dupCertPtr); ret == 0 {
+				return deletedAny, fmt.Errorf("Failed deleting certificate: %v", err)
+			}
+			deletedAny = true
+		}
+	}
+	return deletedAny, nil
+}


### PR DESCRIPTION
This PR creates a new package duplicating the truststore logic into its own package.

My intent is for a subsequent PR to refactor `main()` to use the truststore package, and remove truststore logic from the main package.