### PR TITLE
README: Add cd mkcert to build from source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ brew install mkcert
 or build from source (requires Go 1.13+)
 
 ```
-git clone https://github.com/FiloSottile/mkcert
-cd mkcert
+git clone https://github.com/FiloSottile/mkcert && cd mkcert
 go build -ldflags "-X main.Version=$(git describe --tags)"
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ or build from source (requires Go 1.13+)
 
 ```
 git clone https://github.com/FiloSottile/mkcert
+cd mkcert
 go build -ldflags "-X main.Version=$(git describe --tags)"
 ```
 


### PR DESCRIPTION
This adds a missing `cd mkcert` in the instructions to build from source in the README document.