### PR TITLE
set subject CN for client certificates

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -90,6 +90,7 @@ func (m *mkcert) makeCert(hosts []string) {
 
 	if m.client {
 		tpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
+		tpl.Subject.CommonName = hosts[0]
 	} else if len(tpl.IPAddresses) > 0 || len(tpl.DNSNames) > 0 {
 		tpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
 	}


### PR DESCRIPTION
Many TLS servers and configurations perform client authentication
using the subject CN in the client certificate. This change
adds a subject CN to client certificates.

Fixes #257.