### PR TITLE
Make mkcert -help print to stdout instead of stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,8 +106,8 @@ func main() {
 	}
 	flag.Parse()
 	if *helpFlag {
-		fmt.Fprint(flag.CommandLine.Output(), shortUsage)
-		fmt.Fprint(flag.CommandLine.Output(), advancedUsage)
+		fmt.Print(shortUsage)
+		fmt.Print(advancedUsage)
 		return
 	}
 	if *versionFlag {


### PR DESCRIPTION
Currently "mkcert -help" prints to stderr, which is rather annoying as:

	$ mkcert -help | less

Gives us a blank page, as it pipes only stdout. To get any results in
less I need to use:

	$ mkcert 2>&1 | less
	$ mkcert |& less     # Non-standard bash/ zsh

Since the user explicitly asked for help with -help, it doesn't make
much sense to output it to stderr IMHO.