### PR TITLE
Set certificate validity to 1 year to avoid issues with Chrome/Safari

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -63,14 +63,8 @@ func (m *mkcert) makeCert(hosts []string) {
 			OrganizationalUnit: []string{userAndHostname},
 		},
 
-		NotAfter:  time.Now().AddDate(10, 0, 0),
-
-		// Fix the notBefore to temporarily bypass macOS Catalina's limit on
-		// certificate lifespan. Once mkcert provides an ACME server, automation
-		// will be the recommended way to guarantee uninterrupted functionality,
-		// and the lifespan will be shortened to 825 days. See issue 174 and
-		// https://support.apple.com/en-us/HT210176.
-		NotBefore: time.Date(2019, time.June, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:  time.Now().AddDate(1, 0, 0),
+		NotBefore: time.Now(),
 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		BasicConstraintsValid: true,


### PR DESCRIPTION
Set certificate validity to 1 year, to avoid clashing with more restrictive browsers (Apple is limiting to 1 year)