### PR TITLE
Support camel-case name variant of Firefox Dev Edition

### DIFF
--- a/truststore_nss.go
+++ b/truststore_nss.go
@@ -28,6 +28,7 @@ var (
 		"/usr/bin/firefox-nightly",
 		"/usr/bin/firefox-developer-edition",
 		"/Applications/Firefox.app",
+		"/Applications/FirefoxDeveloperEdition.app",
 		"/Applications/Firefox Developer Edition.app",
 		"/Applications/Firefox Nightly.app",
 		"C:\\Program Files\\Mozilla Firefox",


### PR DESCRIPTION
The latest versions of Firefox Developer Edition on macOS seem to use upper camel case naming for the app. This ensures that the CA will be added to the Firefox trust store if using recent versions of FF Dev Edition.