### PR TITLE
Build mkcert for arm64 Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ script:
         -ldflags "-X main.Version=$(git describe --tags)"
   - CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -o "mkcert-$(git describe --tags)-linux-arm"
         -ldflags "-X main.Version=$(git describe --tags)"
+  - CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o "mkcert-$(git describe --tags)-linux-arm64"
+        -ldflags "-X main.Version=$(git describe --tags)"
   - CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o "mkcert-$(git describe --tags)-darwin-amd64"
         -ldflags "-X main.Version=$(git describe --tags)"
   - CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o "mkcert-$(git describe --tags)-windows-amd64.exe"


### PR DESCRIPTION
There isn't a build for arm64 Linux at the moment. This PR adds support for arm64. More details: https://github.com/golang/go/wiki/GoArm