### PR TITLE
Add DNS whitelist option to CA generation

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -280,6 +280,8 @@ func (m *mkcert) makeCertFromCSR() {
 func (m *mkcert) loadCA() {
 	if !pathExists(filepath.Join(m.CAROOT, rootName)) {
 		m.newCA()
+	} else if len(m.dnsWhitelist) > 0 {
+		log.Println("WARN: CA already exists, -permit flag is being ignored")
 	}
 
 	certPEMBlock, err := ioutil.ReadFile(filepath.Join(m.CAROOT, rootName))
@@ -343,6 +345,8 @@ func (m *mkcert) newCA() {
 		BasicConstraintsValid: true,
 		IsCA:                  true,
 		MaxPathLenZero:        true,
+
+		PermittedDNSDomains: m.dnsWhitelist,
 	}
 
 	cert, err := x509.CreateCertificate(rand.Reader, tpl, tpl, pub, priv)


### PR DESCRIPTION
This uses the `NameConstraints` extension to allow for DNS whitelisting on the local CA when it is first generated.

I'm aware that [you've rejected this kind of change before](https://github.com/FiloSottile/mkcert/pull/113#issuecomment-459999460), but I want to clarify why this version is different, addressing those points:

 * This is totally opt-in, and it's not just on `localhost`. You can use this to produce a minimally-responsible CA for any set of domains, as normal.
 *  This makes explicit in the option help that compliance with the whitelist is optional, and cannot be relied on for security purposes.
 * While I agree that being able to read the local private key and therefore forge certificates issued by the local CA is a big pwn, there are two benefits to restricting the local CA:
    1. It allows for certainty that the CA itself has a minimal responsibility, and therefore that different CAs (used for different development purposes) do not overlap in their issuance in a way that would cause problems outside of testing/development.
    2.  If the user's stack *does* check `NameConstraints`, then by Swiss Cheese, it is simply an improvement to security in the unlikely case that a remote attacker tricks the user into issuing a certificate from their local CA. But of course, this is a very minor benefit.