### PR TITLE
fix: Limit cert lifetime to 397 days to align with Googles new policy.

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -56,10 +56,14 @@ func (m *mkcert) makeCert(hosts []string) {
 	fatalIfErr(err, "failed to generate certificate key")
 	pub := priv.(crypto.Signer).Public()
 
-	// Certificates last for 2 years and 3 months, which is always less than
+	// (i) Apple: Certificates last for 2 years and 3 months, which is always less than
 	// 825 days, the limit that macOS/iOS apply to all certificates,
-	// including custom roots. See https://support.apple.com/en-us/HT210176.
-	expiration := time.Now().AddDate(2, 3, 0)
+	// including custom roots. 
+	// @see https://support.apple.com/en-us/HT210176.
+	// (i) Google: Certificate lifetime reduced to align with Googles policy. In effect
+	// on or after 2020-09-01 00:00:00 UTC. Limits certificate lifetime to 398/397 days.
+	// @see https://chromium.googlesource.com/chromium/src/+/refs/tags/90.0.4396.1/net/docs/certificate_lifetimes.md
+	expiration := time.Now().AddDate(1, 1, 1)
 
 	tpl := &x509.Certificate{
 		SerialNumber: randomSerialNumber(),


### PR DESCRIPTION
Aims to fix #331 as proposed in the comments. Limits cert lifetime to 397 days: `.AddDate( 1, 1, 1 )` (y,m,d).