### PR TITLE
Tweak glob pattern to include firefox-trunk profle location

### DIFF
--- a/truststore_linux.go
+++ b/truststore_linux.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	FirefoxProfile = os.Getenv("HOME") + "/.mozilla/firefox/*"
+	FirefoxProfile = os.Getenv("HOME") + "/.mozilla/firefox*/*"
 	NSSBrowsers    = "Firefox and/or Chrome/Chromium"
 
 	SystemTrustFilename string


### PR DESCRIPTION
Ubuntu team has ppa:ubuntu-mozilla-daily/ppa which provides firefox-trunk
It creates profile under $HOME/.mozilla/firefox-trunk.