### PR TITLE
Feature | Use OSX password prompt

### DIFF
--- a/main.go
+++ b/main.go
@@ -375,6 +375,10 @@ func binaryExists(name string) bool {
 
 var sudoWarningOnce sync.Once
 
+func commandWithSudoNoPrompt(cmd ...string) *exec.Cmd {
+	return exec.Command("sudo", cmd...)
+}
+
 func commandWithSudo(cmd ...string) *exec.Cmd {
 	if u, err := user.Current(); err == nil && u.Uid == "0" {
 		return exec.Command(cmd[0], cmd[1:]...)

--- a/truststore_darwin.go
+++ b/truststore_darwin.go
@@ -50,7 +50,7 @@ var trustSettingsData = []byte(`
 `)
 
 func (m *mkcert) installPlatform() bool {
-	cmd := commandWithSudo("security", "add-trusted-cert", "-d", "-k", "/Library/Keychains/System.keychain", filepath.Join(m.CAROOT, rootName))
+	cmd := commandWithSudoNoPrompt("security", "add-trusted-cert", "-d", "-k", "/Library/Keychains/System.keychain", filepath.Join(m.CAROOT, rootName))
 	out, err := cmd.CombinedOutput()
 	fatalIfCmdErr(err, "security add-trusted-cert", out)
 
@@ -61,7 +61,7 @@ func (m *mkcert) installPlatform() bool {
 	fatalIfErr(err, "failed to create temp file")
 	defer os.Remove(plistFile.Name())
 
-	cmd = commandWithSudo("security", "trust-settings-export", "-d", plistFile.Name())
+	cmd = commandWithSudoNoPrompt("security", "trust-settings-export", "-d", plistFile.Name())
 	out, err = cmd.CombinedOutput()
 	fatalIfCmdErr(err, "security trust-settings-export", out)
 
@@ -95,7 +95,7 @@ func (m *mkcert) installPlatform() bool {
 	err = ioutil.WriteFile(plistFile.Name(), plistData, 0600)
 	fatalIfErr(err, "failed to write trust settings")
 
-	cmd = commandWithSudo("security", "trust-settings-import", "-d", plistFile.Name())
+	cmd = commandWithSudoNoPrompt("security", "trust-settings-import", "-d", plistFile.Name())
 	out, err = cmd.CombinedOutput()
 	fatalIfCmdErr(err, "security trust-settings-import", out)
 
@@ -103,7 +103,7 @@ func (m *mkcert) installPlatform() bool {
 }
 
 func (m *mkcert) uninstallPlatform() bool {
-	cmd := commandWithSudo("security", "remove-trusted-cert", "-d", filepath.Join(m.CAROOT, rootName))
+	cmd := commandWithSudoNoPrompt("security", "remove-trusted-cert", "-d", filepath.Join(m.CAROOT, rootName))
 	out, err := cmd.CombinedOutput()
 	fatalIfCmdErr(err, "security remove-trusted-cert", out)
 


### PR DESCRIPTION
Instead of asking for password with the custom "Sudo password" prompt
use the osx password prompt by attempting to run a "sudo-required"
command.

This will prompt as follows on OSX, even is there's a typo in the password, we
have retry capabilities by using the native password prompt feature.

![image](https://user-images.githubusercontent.com/34756077/120127336-24fc5c00-c18d-11eb-95bd-68fdec4fadc7.png)