### PR TITLE
Add Windows arm64 build to CI pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o "mkcert-$(git describe --tags)-linux-arm64" -ldflags "-X main.Version=$(git describe --tags)"
           CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o "mkcert-$(git describe --tags)-darwin-amd64" -ldflags "-X main.Version=$(git describe --tags)"
           CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o "mkcert-$(git describe --tags)-windows-amd64.exe" -ldflags "-X main.Version=$(git describe --tags)"
+          CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -o "mkcert-$(git describe --tags)-windows-arm64.exe" -ldflags "-X main.Version=$(git describe --tags)"
       - name: Upload release artifacts
         uses: actions/github-script@v3
         with:
@@ -42,5 +43,5 @@ jobs:
                 release_id: release.data.id,
                 name: file,
                 data: await fs.readFile(file),
-              });            
+              });
             }


### PR DESCRIPTION
Go 1.17 [added support for Windows arm64](https://golang.org/doc/go1.17#windows). This PR adds Windows arm64 to the CI pipeline.