### PR TITLE
Added an expiry date flag (-expires) allowing to set an expiry date to the generated certificate

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -34,6 +34,8 @@ import (
 
 var userAndHostname string
 
+const certExpiryDateFormat string = "Mon Jan 2 15:04:05 2006"
+
 func init() {
 	u, err := user.Current()
 	if err == nil {
@@ -59,7 +61,7 @@ func (m *mkcert) makeCert(hosts []string) {
 	// Certificates last for 2 years and 3 months, which is always less than
 	// 825 days, the limit that macOS/iOS apply to all certificates,
 	// including custom roots. See https://support.apple.com/en-us/HT210176.
-	expiration := time.Now().AddDate(2, 3, 0)
+	expiration := m.expirationDate
 
 	tpl := &x509.Certificate{
 		SerialNumber: randomSerialNumber(),
@@ -142,7 +144,7 @@ func (m *mkcert) makeCert(hosts []string) {
 		log.Printf("\nThe legacy PKCS#12 encryption password is the often hardcoded default \"changeit\" ℹ️\n\n")
 	}
 
-	log.Printf("It will expire on %s 🗓\n\n", expiration.Format("2 January 2006"))
+	log.Printf("It will expire on %s 🗓\n\n", expiration.Format(certExpiryDateFormat))
 }
 
 func (m *mkcert) printHosts(hosts []string) {
@@ -225,7 +227,7 @@ func (m *mkcert) makeCertFromCSR() {
 	fatalIfErr(err, "failed to parse the CSR")
 	fatalIfErr(csr.CheckSignature(), "invalid CSR signature")
 
-	expiration := time.Now().AddDate(2, 3, 0)
+	expiration := m.expirationDate
 	tpl := &x509.Certificate{
 		SerialNumber:    randomSerialNumber(),
 		Subject:         csr.Subject,
@@ -275,7 +277,7 @@ func (m *mkcert) makeCertFromCSR() {
 
 	log.Printf("\nThe certificate is at \"%s\" ✅\n\n", certFile)
 
-	log.Printf("It will expire on %s 🗓\n\n", expiration.Format("2 January 2006"))
+	log.Printf("It will expire on %s 🗓\n\n", expiration.Format(certExpiryDateFormat))
 }
 
 // loadCA will load or create the CA at CAROOT.


### PR DESCRIPTION
Hi Filippo,

I had to test that a "homemade" HTTP server automatically reloads the server certificate without the need to restart it.
In order to do that, I used your very nice tool to generate a certificate. As I wanted to test the certificate renewal, I needed to first generate a certificate that is expired, start my HTTP server, try a transfer, see it failing (`curl: (60) Peer's Certificate has expired.`), then re-generate a new certificate that will expire later, re-issue the transfer and see it succeeding.

I therefore forked your project and modified to allow me to set a specific expiry date for the certificate to generate. I propose that pull request as a contribution if you believe this is a nice functionality you would like to port in the official version of your tool. 

I never programmed in Go before, so please forgive me if you spot ugly things :D 

Cheers,
Cedric