### PR TITLE
Add FreeBSD support

### DIFF
--- a/truststore_freebsd.go
+++ b/truststore_freebsd.go
@@ -1,0 +1,50 @@
+// Copyright 2018 The mkcert Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const _certstore = "/etc/ssl/certs"
+
+var (
+	FirefoxProfiles     = []string{os.Getenv("HOME") + "/.mozilla/firefox/*"}
+	NSSBrowsers         = "Firefox and/or Chrome/Chromium"
+	SystemTrustFilename string
+	SystemTrustCommand  []string
+	CertutilInstallHelp string
+)
+
+func (m *mkcert) systemTrustFilename() string {
+	return fmt.Sprintf(SystemTrustFilename, strings.Replace(m.caUniqueName(), " ", "_", -1))
+}
+
+func (m *mkcert) installPlatform() bool {
+	if !pathExists(_certstore) {
+		log.Print("Unable to find FreeBSD cert system store - caroot base pkg is  missing.")
+		log.Printf("You can manually install the root certificate at %q.", filepath.Join(m.CAROOT, rootName))
+		return false
+	}
+	cert, err := os.ReadFile(filepath.Join(m.CAROOT, rootName))
+	fatalIfErr(err, "failed to read root certificate")
+	os.WriteFile(filepath.Join(_certstore, rootName), cert, 0o444)
+	return true
+}
+
+func (m *mkcert) uninstallPlatform() bool {
+	legacyFilename := filepath.Join(_certstore, "rootCA.pem")
+	if !pathExists(legacyFilename) {
+		log.Print("Failed to remove root certificate.")
+		return false
+	}
+	err := os.Remove(legacyFilename)
+	fatalIfErr(err, "failed to remove certificate")
+	return true
+}

--- a/truststore_freebsd.go
+++ b/truststore_freebsd.go
@@ -28,7 +28,7 @@ func (m *mkcert) systemTrustFilename() string {
 
 func (m *mkcert) installPlatform() bool {
 	if !pathExists(_certstore) {
-		log.Print("Unable to find FreeBSD cert system store - caroot base pkg is  missing.")
+		log.Print("FreeBSD caroot base pkg is missing.")
 		log.Printf("You can manually install the root certificate at %q.", filepath.Join(m.CAROOT, rootName))
 		return false
 	}
@@ -39,12 +39,7 @@ func (m *mkcert) installPlatform() bool {
 }
 
 func (m *mkcert) uninstallPlatform() bool {
-	legacyFilename := filepath.Join(_certstore, "rootCA.pem")
-	if !pathExists(legacyFilename) {
-		log.Print("Failed to remove root certificate.")
-		return false
-	}
-	err := os.Remove(legacyFilename)
+	err := os.Remove(filepath.Join(_certstore, "rootCA.pem"))
 	fatalIfErr(err, "failed to remove certificate")
 	return true
 }


### PR DESCRIPTION
This PR adds FreeBSD (plain and simple systemstore) support.

With this commit: 
* Mkcert finally compiles on FreeBSD
* build & use cases tested on hw arm32/arm64/amd64
* detects if the fbsd caroot base pkg or compatible is installed.
* If true, it installs the cert into the system store.

Optional Background Info Notes:
* FreeBSD does by default not enforce the use of su, sudo or doas.
* There is a dedicated 'tool' (script) certctl https://cgit.freebsd.org/src/tree/usr.sbin/certctl/certctl.sh
* It manages by default the usual nss trust dumpster via *hash-id* symlinks within /usr/share/...
* Hiding a mitm abuseable cert in the dumpsters via hash-id might be not a good idea, so i skiped the link part.

Greetings, 
Michael 