### PR TITLE
add CommonName to generated certificates

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -64,6 +64,7 @@ func (m *mkcert) makeCert(hosts []string) {
 	tpl := &x509.Certificate{
 		SerialNumber: randomSerialNumber(),
 		Subject: pkix.Name{
+			CommonName:         hosts[0],
 			Organization:       []string{"mkcert development certificate"},
 			OrganizationalUnit: []string{userAndHostname},
 		},


### PR DESCRIPTION
Adding a CN to the subject makes generated certificates usable in DSM (Synology).

I created a certificate, uploaded it to my DSM and are able to use it for example as "System default" certificate. Also DSM now shows a "Issued to:" value:
![image](https://user-images.githubusercontent.com/221837/212713162-9a4a9de5-9a32-4ff3-a246-ee74654b4a5f.png)

Without this patch, "Issued to:" was empty and the certificate was not selectable for any usages.

Fixes FiloSottile/mkcert#469