### PR TITLE
added ExtKeyUsage to root CA

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -340,7 +340,8 @@ func (m *mkcert) newCA() {
 		NotAfter:  time.Now().AddDate(10, 0, 0),
 		NotBefore: time.Now(),
 
-		KeyUsage: x509.KeyUsageCertSign,
+		KeyUsage:    x509.KeyUsageCertSign,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 
 		BasicConstraintsValid: true,
 		IsCA:                  true,


### PR DESCRIPTION
Fixed my [issue](https://github.com/FiloSottile/mkcert/issues/504) by adding ExtKeyUsage to root CA.

I'm not sure EKU I used is actually correct ones, but it works fine.