### PR TITLE
Add a -days flag to specify the validity period.

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -59,7 +59,7 @@ func (m *mkcert) makeCert(hosts []string) {
 	// Certificates last for 2 years and 3 months, which is always less than
 	// 825 days, the limit that macOS/iOS apply to all certificates,
 	// including custom roots. See https://support.apple.com/en-us/HT210176.
-	expiration := time.Now().AddDate(2, 3, 0)
+	expiration := time.Now().AddDate(0, 0, m.days)
 
 	tpl := &x509.Certificate{
 		SerialNumber: randomSerialNumber(),
@@ -225,7 +225,7 @@ func (m *mkcert) makeCertFromCSR() {
 	fatalIfErr(err, "failed to parse the CSR")
 	fatalIfErr(csr.CheckSignature(), "invalid CSR signature")
 
-	expiration := time.Now().AddDate(2, 3, 0)
+	expiration := time.Now().AddDate(0, 0, m.days)
 	tpl := &x509.Certificate{
 		SerialNumber:    randomSerialNumber(),
 		Subject:         csr.Subject,

--- a/main.go
+++ b/main.go
@@ -68,6 +68,10 @@ const advancedUsage = `Advanced options:
 	-CAROOT
 	    Print the CA certificate and key storage location.
 
+	-days INT
+		Generate a certificate valid for the specified number of days.
+		The default is 810, which is just under the macOS/iOS limit of 825.
+
 	$CAROOT (environment variable)
 	    Set the CA certificate and key storage location. (This allows
 	    maintaining multiple local CAs in parallel.)
@@ -103,6 +107,7 @@ func main() {
 		keyFileFlag   = flag.String("key-file", "", "")
 		p12FileFlag   = flag.String("p12-file", "", "")
 		versionFlag   = flag.Bool("version", false, "")
+		daysFlag      = flag.Int("days", 810, "")
 	)
 	flag.Usage = func() {
 		fmt.Fprint(flag.CommandLine.Output(), shortUsage)
@@ -146,6 +151,7 @@ func main() {
 		installMode: *installFlag, uninstallMode: *uninstallFlag, csrPath: *csrFlag,
 		pkcs12: *pkcs12Flag, ecdsa: *ecdsaFlag, client: *clientFlag,
 		certFile: *certFileFlag, keyFile: *keyFileFlag, p12File: *p12FileFlag,
+		days: *daysFlag,
 	}).Run(flag.Args())
 }
 
@@ -157,6 +163,7 @@ type mkcert struct {
 	pkcs12, ecdsa, client      bool
 	keyFile, certFile, p12File string
 	csrPath                    string
+	days                       int
 
 	CAROOT string
 	caCert *x509.Certificate


### PR DESCRIPTION
The hard-coded default of 2 years, 3 months works for most applications. However, some applications enforce that the certificate is only valid for a short period and this default is too long.

For example, WebRTC fingerprinting enforces a max duration of 30 days. WebTransport is even more extreme and rejects certs valid for more than 14 days. These certificates are meant to be ephemeral.

Fixes #339 #343