### PR TITLE
Add support for Firefox Nightly on Ubuntu

### DIFF
--- a/truststore_linux.go
+++ b/truststore_linux.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	FirefoxProfiles = []string{os.Getenv("HOME") + "/.mozilla/firefox/*",
+		os.Getenv("HOME") + "/.mozilla/firefox-trunk/*",
 		os.Getenv("HOME") + "/snap/firefox/common/.mozilla/firefox/*"}
 	NSSBrowsers = "Firefox and/or Chrome/Chromium"
 


### PR DESCRIPTION
Firefox Nightly on Ubuntu (installed from the dedicated PPA hosting daily builds at https://launchpad.net/~ubuntu-mozilla-daily/+archive/ubuntu/ppa) uses `firefox-trunk` instead of `firefox` to store its profiles, to be able to use it in parallel of released versions without conflicts.