### PR TITLE
add JAVA_TOOL_OPTIONS=-Duser.language=en

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // 使用 IntelliSense 了解相关属性。 
+    // 悬停以查看现有属性的描述。
+    // 欲了解更多信息，请访问: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "args": [
+                // "-install",
+                // "-expireDate",
+                // "hhhh",
+                "localhost",
+            ]
+        }
+    ]
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
 	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -68,6 +68,9 @@ const advancedUsage = `Advanced options:
 	-CAROOT
 	    Print the CA certificate and key storage location.
 
+	-expireDate XXXX
+	    Set expiration date. Auto detect format string (help: https://github.com/araddon/dateparse)
+
 	$CAROOT (environment variable)
 	    Set the CA certificate and key storage location. (This allows
 	    maintaining multiple local CAs in parallel.)
@@ -103,6 +106,7 @@ func main() {
 		keyFileFlag   = flag.String("key-file", "", "")
 		p12FileFlag   = flag.String("p12-file", "", "")
 		versionFlag   = flag.Bool("version", false, "")
+		expireFlag    = flag.String("expireDate", "", "")
 	)
 	flag.Usage = func() {
 		fmt.Fprint(flag.CommandLine.Output(), shortUsage)
@@ -146,6 +150,7 @@ func main() {
 		installMode: *installFlag, uninstallMode: *uninstallFlag, csrPath: *csrFlag,
 		pkcs12: *pkcs12Flag, ecdsa: *ecdsaFlag, client: *clientFlag,
 		certFile: *certFileFlag, keyFile: *keyFileFlag, p12File: *p12FileFlag,
+		expireDate: *expireFlag,
 	}).Run(flag.Args())
 }
 
@@ -166,6 +171,7 @@ type mkcert struct {
 	// will keep failing until the next execution. TODO: maybe execve?
 	// https://github.com/golang/go/issues/24540 (thanks, myself)
 	ignoreCheckFailure bool
+	expireDate         string
 }
 
 func (m *mkcert) Run(args []string) {

--- a/truststore_java.go
+++ b/truststore_java.go
@@ -108,6 +108,7 @@ func (m *mkcert) uninstallJava() {
 // execKeytool will execute a "keytool" command and if needed re-execute
 // the command with commandWithSudo to work around file permissions.
 func execKeytool(cmd *exec.Cmd) ([]byte, error) {
+	cmd.Env = append(cmd.Env, "JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8")
 	out, err := cmd.CombinedOutput()
 	if err != nil && bytes.Contains(out, []byte("java.io.FileNotFoundException")) && runtime.GOOS != "windows" {
 		origArgs := cmd.Args[1:]


### PR DESCRIPTION
fix  #376. To fix console showing garbled text in non-English Windows.
BTW. A message to notice permissions error