### PR TITLE
Certificate expiration is limited to 13 months by android browsers

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -59,7 +59,7 @@ func (m *mkcert) makeCert(hosts []string) {
 	// Certificates last for 2 years and 3 months, which is always less than
 	// 825 days, the limit that macOS/iOS apply to all certificates,
 	// including custom roots. See https://support.apple.com/en-us/HT210176.
-	expiration := time.Now().AddDate(2, 3, 0)
+	expiration := time.Now().AddDate(1, 0, 0)
 
 	tpl := &x509.Certificate{
 		SerialNumber: randomSerialNumber(),
@@ -225,7 +225,7 @@ func (m *mkcert) makeCertFromCSR() {
 	fatalIfErr(err, "failed to parse the CSR")
 	fatalIfErr(csr.CheckSignature(), "invalid CSR signature")
 
-	expiration := time.Now().AddDate(2, 3, 0)
+	expiration := time.Now().AddDate(1, 0, 0)
 	tpl := &x509.Certificate{
 		SerialNumber:    randomSerialNumber(),
 		Subject:         csr.Subject,


### PR DESCRIPTION
Chromium on android (at least) shows a "ERR_CERT_VALIDITY_TOO_LONG" error when the certification expiration is more than 397 days.