### PR TITLE
Add Linux install with https://github.com/marcosnils/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Then you can install using [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-
 brew install mkcert
 ```
 
+or install using [bin](https://github.com/marcosnils/bin)
+
+```
+bin install https://github.com/FiloSottile/mkcert
+```
+
 or build from source (requires Go 1.13+)
 
 ```


### PR DESCRIPTION
mkcert installs perfectly with https://github.com/marcosnils/bin and may be an easier option for some users.