### PR TITLE
no ExtKeyUsageServerAuth with -client

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -87,8 +87,7 @@ func (m *mkcert) makeCert(hosts []string) {
 
 	if m.client {
 		tpl.ExtKeyUsage = append(tpl.ExtKeyUsage, x509.ExtKeyUsageClientAuth)
-	}
-	if len(tpl.IPAddresses) > 0 || len(tpl.DNSNames) > 0 || len(tpl.URIs) > 0 {
+	} else if len(tpl.IPAddresses) > 0 || len(tpl.DNSNames) > 0 || len(tpl.URIs) > 0 {
 		tpl.ExtKeyUsage = append(tpl.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
 	}
 	if len(tpl.EmailAddresses) > 0 {


### PR DESCRIPTION
client and server auth extensions don't mix together well, esp. on windows Server 10.