### PR TITLE
Make clear that root password prompt is coming from sudo, not mkcert

### DIFF
--- a/main.go
+++ b/main.go
@@ -389,5 +389,6 @@ func commandWithSudo(cmd ...string) *exec.Cmd {
 		})
 		return exec.Command(cmd[0], cmd[1:]...)
 	}
-	return exec.Command("sudo", append([]string{"--prompt=Sudo password:", "--"}, cmd...)...)
+	log.Println("Re-running with sudo (your password will not be processed or saved by mkcert)")
+	return exec.Command("sudo", append([]string{"--"}, cmd...)...)
 }


### PR DESCRIPTION
Given the sensitive nature of passwords of users with sudo privileges, I propose to preserve the default behaviour (and prompt) of sudo as the user may expect, and instead print an explanatory message stating that mkcert is re-running with sudo.

Issue #178 led to commit https://github.com/FiloSottile/mkcert/commit/aa4dd610664a3b092f35cb7c996d94e3c3da6159 which added the `--prompt Sudo password:` argument to the sudo command when re-running with elevated permissions. While a reasonable solution to the potential "which password is required?" confusion users may face, for users unfamiliar with the `--prompt` argument to sudo, it can cause concern that the user's password is being captured and processed by mkcert itself, and not by sudo (an insecure and unfortunately not uncommon action taken by some applications, like Zoom - see https://www.vmray.com/cyber-security-blog/zoom-macos-installer-analysis-good-apps-behaving-badly/).

This PR seeks to make it clearer to users that the password prompt is coming from sudo and not mkcert, while still explaining to users which password is being requested.

(When first trying `mkcert -install` and seeing the "Sudo password:" prompt, I worried that it would be capturing and saving my password for future elevation, and had to read the source to find out what was really happening - users less familiar with Go may have struggled with this).