### PR TITLE
Fix install instructions to work on arm

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ go build -ldflags "-X main.Version=$(git describe --tags)"
 or use [the pre-built binaries](https://github.com/FiloSottile/mkcert/releases).
 
 ```
-arch=$(uname -m); if [ "$arch" = "x86_64" ]; then arch="amd64"; else arch="arm64"; fi && curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/$arch"
+arch=$(uname -m); if [ "$arch" = "x86_64" ]; then arch="amd64"; elif [ "$arch" = "armv7l" ]; then arch="arm"; else arch="arm64"; fi && curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/$arch"
 chmod +x mkcert-v*-linux-a*64
 sudo cp mkcert-v*-linux-a*64 /usr/local/bin/mkcert
 ```

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ or use [the pre-built binaries](https://github.com/FiloSottile/mkcert/releases).
 
 ```
 arch=$(uname -m); if [ "$arch" = "x86_64" ]; then arch="amd64"; elif [ "$arch" = "armv7l" ]; then arch="arm"; else arch="arm64"; fi && curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/$arch"
-chmod +x mkcert-v*-linux-a*64
-sudo cp mkcert-v*-linux-a*64 /usr/local/bin/mkcert
+chmod +x mkcert-v*-linux-a*
+sudo cp mkcert-v*-linux-a* /usr/local/bin/mkcert
 ```
 
 For Arch Linux users, [`mkcert`](https://archlinux.org/packages/extra/x86_64/mkcert/) is available on the official Arch Linux repository.

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ go build -ldflags "-X main.Version=$(git describe --tags)"
 or use [the pre-built binaries](https://github.com/FiloSottile/mkcert/releases).
 
 ```
-curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"
-chmod +x mkcert-v*-linux-amd64
-sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
+arch=$(uname -m); if [ "$arch" = "x86_64" ]; then arch="amd64"; else arch="arm64"; fi && curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/$arch"
+chmod +x mkcert-v*-linux-a*64
+sudo cp mkcert-v*-linux-a*64 /usr/local/bin/mkcert
 ```
 
 For Arch Linux users, [`mkcert`](https://archlinux.org/packages/extra/x86_64/mkcert/) is available on the official Arch Linux repository.


### PR DESCRIPTION
The install instructions currently assume the user is using x64, leading to it failing to fetch the correct binary on an arm architecture such as on raspberry pi's.

It'll now detect which arch is being used, and will use the appropriate package.