### PR TITLE
Prefix message to clarify what is asking for sudo password

### DIFF
--- a/main.go
+++ b/main.go
@@ -389,5 +389,5 @@ func commandWithSudo(cmd ...string) *exec.Cmd {
 		})
 		return exec.Command(cmd[0], cmd[1:]...)
 	}
-	return exec.Command("sudo", append([]string{"--prompt=Sudo password:", "--"}, cmd...)...)
+	return exec.Command("sudo", append([]string{"--prompt=[mkcert] sudo password:", "--"}, cmd...)...)
 }

--- a/main.go
+++ b/main.go
@@ -389,5 +389,5 @@ func commandWithSudo(cmd ...string) *exec.Cmd {
 		})
 		return exec.Command(cmd[0], cmd[1:]...)
 	}
-	return exec.Command("sudo", append([]string{"--prompt=[mkcert] sudo password:", "--"}, cmd...)...)
+	return exec.Command("sudo", append([]string{"--prompt=mkcert will now install certificates into your root certificate store.\nEnter your sudo password:", "--"}, cmd...)...)
 }


### PR DESCRIPTION
I was type checking a javascript file and through a roundabout manner it was invoking mkcert. It was quite scary that such a simple operation was asking for my sudo password without any explanation of where it was coming from or why it was needed. For such a sensitive operation I think it would be helpful to provide more details

This PR uses the text:
>mkcert will now install certificates into your root certificate store.
Enter your sudo password:

If we wanted something shorter another alternative might be:
>[mkcert] sudo password:

But I thought the longer message provided more explanation of _why_ it's asking for your sudo password.