### PR TITLE
append JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8

### DIFF
--- a/truststore_java.go
+++ b/truststore_java.go
@@ -108,6 +108,7 @@ func (m *mkcert) uninstallJava() {
 // execKeytool will execute a "keytool" command and if needed re-execute
 // the command with commandWithSudo to work around file permissions.
 func execKeytool(cmd *exec.Cmd) ([]byte, error) {
+	cmd.Env = append(cmd.Env, "JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8")
 	out, err := cmd.CombinedOutput()
 	if err != nil && bytes.Contains(out, []byte("java.io.FileNotFoundException")) && runtime.GOOS != "windows" {
 		origArgs := cmd.Args[1:]


### PR DESCRIPTION
fix https://github.com/FiloSottile/mkcert/issues/376. To fix console showing garbled text in non-English System.