### PR TITLE
README: add installation method using go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Then you can install using [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-
 brew install mkcert
 ```
 
+or install using `go install` (requires Go 1.17+)
+
+```
+go install filippo.io/mkcert@latest
+```
+
 or build from source (requires Go 1.13+)
 
 ```


### PR DESCRIPTION
I think it's strange that this method wasn't mentioned. so I decided to add it:
```
go install filippo.io/mkcert@latest
```