### PR TITLE
Bump GitHub action workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: 1.x
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build binaries
         run: |
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "mkcert-$(git describe --tags)-linux-amd64" -ldflags "-X main.Version=$(git describe --tags)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go ${{ matrix.go }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: 1.x
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run staticcheck
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest


### PR DESCRIPTION
This PR bumps GitHub workflow actions to their latest versions, thus avoiding deprecation warnings as shown e.g. [here](https://github.com/FiloSottile/mkcert/actions/runs/8735108653).