### PR TITLE
Update README.md - adding winget

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ scoop bucket add extras
 scoop install mkcert
 ```
 
+or use [Winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/)
+
+```
+winget install -e --id FiloSottile.mkcert
+```
+
 or build from source (requires Go 1.10+), or use [the pre-built binaries](https://github.com/FiloSottile/mkcert/releases).
 
 If you're running into permission problems try running `mkcert` as an Administrator.


### PR DESCRIPTION
Referencing this comment https://github.com/FiloSottile/mkcert/issues/400#issuecomment-913498460 in the #400 issue, seems like it's ok for the creator of this pkg to also let people use winget.

thanks to @ItzLevvie this can be used.
the official commit for winget, that references the packages from this repo release(mkcert), is here if anyone needs to take a look:
https://github.com/microsoft/winget-pkgs/commit/0a8b8f08a46f22599c9db65b11b64f211d457b75

I believe this should be included in the docs because it's just really convenient.