### PR TITLE
feat: Refactor organizational unit handling in certificate generation

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -32,9 +32,8 @@ import (
 	pkcs12 "software.sslmate.com/src/go-pkcs12"
 )
 
-var userAndHostname string
-
-func init() {
+func defaultOrganizationalUnit() string {
+	var userAndHostname string
 	u, err := user.Current()
 	if err == nil {
 		userAndHostname = u.Username + "@"
@@ -45,6 +44,7 @@ func init() {
 	if err == nil && u.Name != "" && u.Name != u.Username {
 		userAndHostname += " (" + u.Name + ")"
 	}
+	return userAndHostname
 }
 
 func (m *mkcert) makeCert(hosts []string) {
@@ -65,7 +65,7 @@ func (m *mkcert) makeCert(hosts []string) {
 		SerialNumber: randomSerialNumber(),
 		Subject: pkix.Name{
 			Organization:       []string{"mkcert development certificate"},
-			OrganizationalUnit: []string{userAndHostname},
+			OrganizationalUnit: []string{m.organizationalUnit},
 		},
 
 		NotBefore: time.Now(), NotAfter: expiration,
@@ -328,12 +328,12 @@ func (m *mkcert) newCA() {
 		SerialNumber: randomSerialNumber(),
 		Subject: pkix.Name{
 			Organization:       []string{"mkcert development CA"},
-			OrganizationalUnit: []string{userAndHostname},
+			OrganizationalUnit: []string{m.organizationalUnit},
 
 			// The CommonName is required by iOS to show the certificate in the
 			// "Certificate Trust Settings" menu.
 			// https://github.com/FiloSottile/mkcert/issues/47
-			CommonName: "mkcert " + userAndHostname,
+			CommonName: "mkcert " + m.organizationalUnit,
 		},
 		SubjectKeyId: skid[:],
 

--- a/main.go
+++ b/main.go
@@ -91,18 +91,19 @@ func main() {
 	}
 	log.SetFlags(0)
 	var (
-		installFlag   = flag.Bool("install", false, "")
-		uninstallFlag = flag.Bool("uninstall", false, "")
-		pkcs12Flag    = flag.Bool("pkcs12", false, "")
-		ecdsaFlag     = flag.Bool("ecdsa", false, "")
-		clientFlag    = flag.Bool("client", false, "")
-		helpFlag      = flag.Bool("help", false, "")
-		carootFlag    = flag.Bool("CAROOT", false, "")
-		csrFlag       = flag.String("csr", "", "")
-		certFileFlag  = flag.String("cert-file", "", "")
-		keyFileFlag   = flag.String("key-file", "", "")
-		p12FileFlag   = flag.String("p12-file", "", "")
-		versionFlag   = flag.Bool("version", false, "")
+		installFlag            = flag.Bool("install", false, "")
+		uninstallFlag          = flag.Bool("uninstall", false, "")
+		pkcs12Flag             = flag.Bool("pkcs12", false, "")
+		ecdsaFlag              = flag.Bool("ecdsa", false, "")
+		clientFlag             = flag.Bool("client", false, "")
+		helpFlag               = flag.Bool("help", false, "")
+		carootFlag             = flag.Bool("CAROOT", false, "")
+		csrFlag                = flag.String("csr", "", "")
+		organizationalUnitFlag = flag.String("organizational-unit", defaultOrganizationalUnit(), "")
+		certFileFlag           = flag.String("cert-file", "", "")
+		keyFileFlag            = flag.String("key-file", "", "")
+		p12FileFlag            = flag.String("p12-file", "", "")
+		versionFlag            = flag.Bool("version", false, "")
 	)
 	flag.Usage = func() {
 		fmt.Fprint(flag.CommandLine.Output(), shortUsage)
@@ -144,7 +145,8 @@ func main() {
 	}
 	(&mkcert{
 		installMode: *installFlag, uninstallMode: *uninstallFlag, csrPath: *csrFlag,
-		pkcs12: *pkcs12Flag, ecdsa: *ecdsaFlag, client: *clientFlag,
+		organizationalUnit: *organizationalUnitFlag,
+		pkcs12:             *pkcs12Flag, ecdsa: *ecdsaFlag, client: *clientFlag,
 		certFile: *certFileFlag, keyFile: *keyFileFlag, p12File: *p12FileFlag,
 	}).Run(flag.Args())
 }
@@ -157,6 +159,7 @@ type mkcert struct {
 	pkcs12, ecdsa, client      bool
 	keyFile, certFile, p12File string
 	csrPath                    string
+	organizationalUnit         string
 
 	CAROOT string
 	caCert *x509.Certificate


### PR DESCRIPTION
The automatically generated `OrganizationalUnit` was too long. Also, there was no way to customize it. It was very inconvenient to use. Therefore, an additional parameter was added to allow customization of this parameter.